### PR TITLE
feat: MVP6 Refined - End-User Refund Pages

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1,14 +1,31 @@
 version: "3.9"
 
 services:
+  db:
+    image: mysql:8.0
+    container_name: mysql-db
+    ports:
+      - "3307:3306"
+    environment:
+      MYSQL_ROOT_PASSWORD: rootpassword
+      MYSQL_DATABASE: BookHive
+      MYSQL_USER: myuser
+      MYSQL_PASSWORD: "123456"
+    volumes:
+      - mysql_data:/var/lib/mysql
+    networks:
+      - mynetwork
+
   backend:
     image: fastapi:latest
     build: ./fastapi              # Path to backend Dockerfile
     container_name: fastapi-backend
-    expose:
-      - "8000"               # Host:Container
+    ports:
+      - "8000:8000"          # Host:Container
     env_file:
-      - ./.env 
+      - ./.env
+    depends_on:
+      - db
     networks:
       - mynetwork
 
@@ -16,8 +33,8 @@ services:
     image: frontendnext:latest
     build: ./frontendNext             # Path to frontend Dockerfile
     container_name: next-frontend
-    expose:
-      - "3000"               # Host:Container
+    ports:
+      - "3000:3000"          # Host:Container
     env_file:
       - ./.env 
     depends_on:
@@ -44,6 +61,9 @@ services:
     networks:
       - mynetwork
 
+
+volumes:
+  mysql_data:
 
 networks:
   mynetwork:

--- a/fastapi/routes/payment_gateway.py
+++ b/fastapi/routes/payment_gateway.py
@@ -17,6 +17,7 @@ from models.payment_gateway import (
     DonationResponse,
     StripeWebhookEvent
 )
+from typing import Optional
 
 router = APIRouter(prefix="/payment_gateway", tags=["Payment_gateway"])
 
@@ -182,6 +183,97 @@ def cancel_order_with_refund(order_id: str, db: Session = Depends(get_db)):
     """
     result = payment_gateway_service.refund_on_cancel(db=db, order_id=order_id, actor="user")
     return result
+
+
+@router.get("/refunds/user/{user_id}", status_code=status.HTTP_200_OK)
+def get_user_refunds(user_id: str, db: Session = Depends(get_db)):
+    """
+    Get all refund records for a specific user (as borrower).
+    Returns refunds with order info, book titles, amounts, statuses.
+    """
+    from models.order import Order, OrderBook
+    from models.payment_split import PaymentSplit
+    from models.payment_gateway import Refund, Payment, AuditLog
+    from models.book import Book
+
+    # Find all orders where user is the borrower
+    orders = db.query(Order).filter(Order.borrower_id == user_id).all()
+    if not orders:
+        return {"user_id": user_id, "refunds": []}
+
+    result = []
+    for order in orders:
+        sp = db.query(PaymentSplit).filter(PaymentSplit.order_id == order.id).first()
+        if not sp:
+            continue
+
+        refunds = (
+            db.query(Refund)
+            .filter(Refund.payment_id == sp.payment_id)
+            .order_by(Refund.created_at.desc())
+            .all()
+        )
+        if not refunds:
+            continue
+
+        # Get book titles for this order
+        order_books = db.query(OrderBook).filter(OrderBook.order_id == order.id).all()
+        book_titles = []
+        for ob in order_books:
+            book = db.query(Book).filter(Book.id == ob.book_id).first()
+            if book:
+                book_titles.append(book.title_en or book.title_or or "Unknown")
+
+        # Get audit logs for timeline
+        logs = (
+            db.query(AuditLog)
+            .filter(AuditLog.reference_id == order.id)
+            .order_by(AuditLog.created_at.asc())
+            .all()
+        )
+
+        for r in refunds:
+            # Determine refund type by comparing amount
+            total_cents = (sp.deposit_cents or 0) + (sp.shipping_cents or 0)
+            if r.amount >= total_cents:
+                refund_type = "full"
+            elif r.amount == (sp.deposit_cents or 0):
+                refund_type = "deposit"
+            elif r.amount == (sp.shipping_cents or 0):
+                refund_type = "shipping"
+            else:
+                refund_type = "partial"
+
+            result.append({
+                "refund_id": r.refund_id,
+                "amount": r.amount,
+                "currency": r.currency,
+                "status": r.status,
+                "reason": r.reason,
+                "refund_type": refund_type,
+                "created_at": r.created_at.isoformat() if r.created_at else None,
+                "updated_at": r.updated_at.isoformat() if r.updated_at else None,
+                "order": {
+                    "order_id": order.id,
+                    "status": order.status,
+                    "book_titles": book_titles,
+                    "created_at": order.created_at.isoformat() if order.created_at else None,
+                    "canceled_at": order.canceled_at.isoformat() if order.canceled_at else None,
+                },
+                "timeline": [
+                    {
+                        "event": log.event_type,
+                        "actor": log.actor,
+                        "message": log.message,
+                        "timestamp": log.created_at.isoformat() if log.created_at else None,
+                    }
+                    for log in logs
+                ],
+            })
+
+    # Sort by newest first
+    result.sort(key=lambda x: x["created_at"] or "", reverse=True)
+    return {"user_id": user_id, "refunds": result}
 
 
 @router.post("/payment/compensate/{payment_id}", status_code=status.HTTP_200_OK)

--- a/fastapi/seed.py
+++ b/fastapi/seed.py
@@ -20,6 +20,7 @@ from database.connection import SessionLocal
 from models.user import User
 from models.book import Book
 from models.order import Order, OrderBook
+from models.payment_gateway import Payment
 from core.security import get_password_hash
 
 
@@ -425,6 +426,111 @@ def seed(*, force: bool = False):
             print(f"  Created order: {order.id} ({o['status']})")
 
         db.commit()
+
+        # --- Seed a CANCELED order with payment + refund for testing ---
+        print("Seeding refund demo data...")
+        from models.payment_gateway import Payment as PaymentModel, Refund, AuditLog
+        from models.payment_split import PaymentSplit
+
+        alice = db.query(User).filter(User.email == "alice@example.com").first()
+        bob = db.query(User).filter(User.email == "bob@example.com").first()
+        book4 = db.query(Book).filter(Book.title_en == "The Hitchhiker's Guide to the Galaxy").first()
+
+        if alice and bob and book4:
+            # Check if refund demo already exists
+            existing_refund = db.query(Refund).filter(Refund.refund_id == "re_mock_demo001").first()
+            if not existing_refund:
+                payment_id = "pi_mock_demo001"
+                refund_order_id = uid()
+                canceled_time = datetime.utcnow() - timedelta(days=1)
+                created_time = canceled_time - timedelta(hours=2)
+
+                # Create Payment
+                payment = PaymentModel(
+                    payment_id=payment_id,
+                    checkout_id="cs_mock_demo001",
+                    user_id=alice.user_id,
+                    amount=1000,
+                    currency="aud",
+                    status="refunded",
+                    deposit=1000,
+                    shipping_fee=0,
+                    service_fee=0,
+                    created_at=created_time,
+                    destination="acct_mock",
+                    action_type="BORROW",
+                )
+                db.add(payment)
+                db.flush()
+
+                # Create CANCELED Order
+                refund_order = Order(
+                    id=refund_order_id,
+                    owner_id=bob.user_id,
+                    borrower_id=alice.user_id,
+                    status="CANCELED",
+                    action_type="borrow",
+                    created_at=created_time,
+                    canceled_at=canceled_time,
+                    shipping_method="pickup",
+                    deposit_or_sale_amount=10.00,
+                    service_fee_amount=0.00,
+                    shipping_out_fee_amount=0.00,
+                    total_paid_amount=10.00,
+                    total_refunded_amount=10.00,
+                    payment_id=payment_id,
+                    estimated_delivery_time=3,
+                    contact_name="Yuan Alice",
+                    phone="0414069405",
+                    street="555 Wellington St",
+                    city="PERTH",
+                    postcode="6000",
+                    country="Australia",
+                )
+                db.add(refund_order)
+                db.flush()
+
+                # Link book to order
+                db.add(OrderBook(order_id=refund_order_id, book_id=book4.id))
+
+                # Create PaymentSplit
+                db.add(PaymentSplit(
+                    payment_id=payment_id,
+                    order_id=refund_order_id,
+                    owner_id=bob.user_id,
+                    connected_account_id="acct_mock",
+                    currency="aud",
+                    deposit_cents=1000,
+                    shipping_cents=0,
+                    service_fee_cents=0,
+                    transfer_amount_cents=0,
+                ))
+
+                # Create Refund record
+                db.add(Refund(
+                    refund_id="re_mock_demo001",
+                    payment_id=payment_id,
+                    amount=1000,
+                    currency="aud",
+                    status="succeeded",
+                    reason="Order cancelled by user",
+                    created_at=canceled_time,
+                ))
+
+                # Create AuditLog
+                db.add(AuditLog(
+                    event_type="refund_on_cancel",
+                    reference_id=refund_order_id,
+                    actor="user",
+                    message="User cancelled order, full refund issued",
+                    created_at=canceled_time,
+                ))
+
+                db.commit()
+                print(f"  Created CANCELED order with refund: {refund_order_id}")
+            else:
+                print("  Refund demo data already exists, skipping.")
+
         print("\nSeed complete!")
         print("\nTest accounts:")
         for u in USERS:

--- a/frontendNext/app/borrowing/[id]/page.tsx
+++ b/frontendNext/app/borrowing/[id]/page.tsx
@@ -3,7 +3,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
-import { Clock, Truck, ArrowLeft, AlertTriangle } from "lucide-react";
+import { Clock, Truck, ArrowLeft, AlertTriangle, ExternalLink } from "lucide-react";
 import CoverImg from "@/app/components/ui/CoverImg";
 import Card from "@/app/components/ui/Card";
 import Button from "@/app/components/ui/Button";
@@ -611,6 +611,18 @@ export default function OrderDetailPage() {
               </p>
             </div>
           )}
+
+          <div className="border-t p-4">
+            <Button
+              variant="outline"
+              size="sm"
+              className="flex items-center gap-2 border-black text-black hover:bg-black hover:text-white"
+              onClick={() => router.push(`/refunds/${id}`)}
+            >
+              <ExternalLink className="w-4 h-4" />
+              View Refund Details
+            </Button>
+          </div>
         </Card>
       )}
 

--- a/frontendNext/app/borrowing/page.tsx
+++ b/frontendNext/app/borrowing/page.tsx
@@ -3,7 +3,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
-import { Search, Filter, Package, Clock, AlertTriangle, ArrowDownCircle, ArrowUpCircle, User as UserIcon } from "lucide-react";
+import { Search, Filter, Package, Clock, AlertTriangle, ArrowDownCircle, ArrowUpCircle, User as UserIcon, RefreshCw } from "lucide-react";
 import CoverImg from "../components/ui/CoverImg";
 import Card from "../components/ui/Card";
 import Button from "../components/ui/Button";
@@ -136,6 +136,14 @@ export default function OrderListPage() {
                 View and manage your borrowing orders
               </p>
             </div>
+            <Button
+              variant="outline"
+              className="flex items-center gap-2 border-black text-black hover:bg-black hover:text-white"
+              onClick={() => router.push("/refunds")}
+            >
+              <RefreshCw className="w-4 h-4" />
+              My Refunds
+            </Button>
           </div>
 
           {/* Search & Filters */}

--- a/frontendNext/app/refunds/[id]/page.tsx
+++ b/frontendNext/app/refunds/[id]/page.tsx
@@ -1,0 +1,397 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+import { ArrowLeft, CheckCircle, Clock, XCircle, AlertCircle, ExternalLink } from "lucide-react";
+import Card from "../../components/ui/Card";
+import Button from "../../components/ui/Button";
+import { getRefundsForOrder } from "@/utils/payments";
+import { getCurrentUser } from "@/utils/auth";
+
+interface RefundRecord {
+  refund_id: string;
+  amount: number;
+  currency: string;
+  status: string;
+  reason: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+interface OrderInfo {
+  id: string;
+  status: string;
+  books: Array<{ bookId: string; titleEn: string; titleOr: string; author: string; coverImgUrl: string }>;
+  createdAt: string | null;
+  canceledAt: string | null;
+  totalPaidAmount: number;
+  totalRefundedAmount: number;
+  depositOrSaleAmount: number;
+  shippingOutFeeAmount: number;
+  serviceFeeAmount: number;
+  paymentId: string | null;
+}
+
+const STATUS_CONFIG: Record<string, { label: string; icon: React.ElementType; className: string; bgClassName: string }> = {
+  succeeded: { label: "Completed", icon: CheckCircle, className: "text-green-600", bgClassName: "bg-green-50 border-green-200" },
+  pending: { label: "Processing", icon: Clock, className: "text-yellow-600", bgClassName: "bg-yellow-50 border-yellow-200" },
+  failed: { label: "Failed", icon: XCircle, className: "text-red-600", bgClassName: "bg-red-50 border-red-200" },
+};
+
+export default function RefundDetailPage() {
+  const params = useParams();
+  const router = useRouter();
+  const orderId = params.id as string;
+
+  const [refunds, setRefunds] = useState<RefundRecord[]>([]);
+  const [order, setOrder] = useState<OrderInfo | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const loadData = async () => {
+      try {
+        setLoading(true);
+        const user = await getCurrentUser();
+        if (!user?.id) {
+          setError("Please log in to view refund details.");
+          return;
+        }
+
+        // Fetch refunds for this order
+        const refundData = await getRefundsForOrder(orderId);
+        setRefunds(refundData.refunds);
+
+        // Fetch order details
+        const { getBorrowingOrders } = await import("@/utils/borrowingOrders");
+        const orders = await getBorrowingOrders();
+        const matchedOrder = orders.find((o: any) => o.order_id === orderId);
+        if (matchedOrder) {
+          setOrder({
+            id: matchedOrder.order_id,
+            status: matchedOrder.status,
+            books: matchedOrder.books.map((b: any) => ({
+              bookId: b.book_id || b.bookId,
+              titleEn: b.title || b.titleEn,
+              titleOr: b.titleOr || "",
+              author: b.author || "",
+              coverImgUrl: b.cover || b.coverImgUrl || "",
+            })),
+            createdAt: matchedOrder.create_at || matchedOrder.createdAt,
+            canceledAt: matchedOrder.canceled_at || matchedOrder.canceledAt,
+            totalPaidAmount: matchedOrder.total_paid || matchedOrder.totalPaidAmount || 0,
+            totalRefundedAmount: matchedOrder.total_refunded || matchedOrder.totalRefundedAmount || 0,
+            depositOrSaleAmount: matchedOrder.deposit || matchedOrder.depositOrSaleAmount || 0,
+            shippingOutFeeAmount: matchedOrder.shipping_fee || matchedOrder.shippingOutFeeAmount || 0,
+            serviceFeeAmount: matchedOrder.service_fee || matchedOrder.serviceFeeAmount || 0,
+            paymentId: matchedOrder.payment_id || matchedOrder.paymentId || null,
+          });
+        }
+      } catch (err) {
+        console.error("Failed to load refund details:", err);
+        setError("Failed to load refund details. Please try again.");
+      } finally {
+        setLoading(false);
+      }
+    };
+    loadData();
+  }, [orderId]);
+
+  const fmtDate = (v?: string | null) => {
+    if (!v) return "-";
+    try {
+      return new Date(v).toLocaleString();
+    } catch {
+      return "Invalid date";
+    }
+  };
+
+  const fmtAmount = (amount: number, currency: string) => {
+    const dollars = (amount / 100).toFixed(2);
+    const sym = currency.toUpperCase() === "AUD" ? "A$" : "$";
+    return `${sym}${dollars} ${currency.toUpperCase()}`;
+  };
+
+  const fmtDollars = (amount: number) => {
+    return `A$${amount.toFixed(2)} AUD`;
+  };
+
+  // Build timeline from order + refund data
+  const buildTimeline = () => {
+    const events: Array<{ label: string; time: string | null; icon: React.ElementType; done: boolean }> = [];
+
+    if (order?.createdAt) {
+      events.push({ label: "Order placed", time: order.createdAt, icon: CheckCircle, done: true });
+    }
+
+    // Payment is always done if order exists
+    if (order) {
+      events.push({ label: "Payment completed", time: order.createdAt, icon: CheckCircle, done: true });
+    }
+
+    if (order?.canceledAt) {
+      events.push({ label: "Order cancelled", time: order.canceledAt, icon: AlertCircle, done: true });
+    }
+
+    if (refunds.length > 0) {
+      const firstRefund = refunds[refunds.length - 1]; // oldest
+      events.push({ label: "Refund initiated", time: firstRefund.created_at, icon: Clock, done: true });
+
+      if (firstRefund.status === "succeeded") {
+        events.push({ label: "Refund completed", time: firstRefund.updated_at || firstRefund.created_at, icon: CheckCircle, done: true });
+      } else if (firstRefund.status === "failed") {
+        events.push({ label: "Refund failed", time: firstRefund.updated_at || firstRefund.created_at, icon: XCircle, done: true });
+      } else {
+        events.push({ label: "Refund processing", time: null, icon: Clock, done: false });
+      }
+    }
+
+    return events;
+  };
+
+  if (loading) {
+    return (
+      <div className="max-w-4xl mx-auto p-6">
+        <Card><div className="p-4 text-gray-600">Loading refund details...</div></Card>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="max-w-4xl mx-auto p-6">
+        <Card><div className="p-4 text-red-600">{error}</div></Card>
+      </div>
+    );
+  }
+
+  if (refunds.length === 0) {
+    return (
+      <div className="max-w-4xl mx-auto p-6">
+        <button onClick={() => router.back()} className="flex items-center gap-1 text-gray-500 hover:text-black mb-4 text-sm">
+          <ArrowLeft className="w-4 h-4" /> Back
+        </button>
+        <Card>
+          <div className="text-center py-12">
+            <AlertCircle className="w-16 h-16 text-gray-300 mx-auto mb-4" />
+            <h3 className="text-lg font-medium text-gray-900 mb-2">No refunds found</h3>
+            <p className="text-gray-500">This order has no refund records.</p>
+          </div>
+        </Card>
+      </div>
+    );
+  }
+
+  const primaryRefund = refunds[0]; // most recent
+  const statusConfig = STATUS_CONFIG[primaryRefund.status] || STATUS_CONFIG["pending"];
+  const StatusIcon = statusConfig.icon;
+  const timeline = buildTimeline();
+
+  return (
+    <div className="flex h-full">
+      <div className="flex-1 overflow-y-auto">
+        <div className="max-w-4xl mx-auto p-6">
+          {/* Back button */}
+          <button
+            onClick={() => router.push("/refunds")}
+            className="flex items-center gap-1 text-gray-500 hover:text-black mb-4 text-sm"
+          >
+            <ArrowLeft className="w-4 h-4" /> Back to My Refunds
+          </button>
+
+          {/* Header */}
+          <div className="mb-6">
+            <h1 className="text-3xl font-bold text-gray-900 mb-1">Refund Details</h1>
+            <p className="text-gray-500 text-sm">Order ID: {orderId}</p>
+          </div>
+
+          {/* Status Banner */}
+          <Card className={`p-5 mb-6 border ${statusConfig.bgClassName}`}>
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-3">
+                <StatusIcon className={`w-8 h-8 ${statusConfig.className}`} />
+                <div>
+                  <h2 className={`text-xl font-bold ${statusConfig.className}`}>
+                    Refund {statusConfig.label}
+                  </h2>
+                  <p className="text-sm text-gray-600 mt-0.5">
+                    {primaryRefund.reason || "No reason provided"}
+                  </p>
+                </div>
+              </div>
+              <div className="text-right">
+                <div className="text-3xl font-bold text-gray-900">
+                  {fmtAmount(primaryRefund.amount, primaryRefund.currency)}
+                </div>
+              </div>
+            </div>
+          </Card>
+
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+            {/* Left Column */}
+            <div className="space-y-6">
+              {/* Timeline */}
+              <Card className="p-5">
+                <h3 className="text-lg font-semibold text-gray-900 mb-4">Order Timeline</h3>
+                <div className="space-y-0">
+                  {timeline.map((event, idx) => {
+                    const Icon = event.icon;
+                    const isLast = idx === timeline.length - 1;
+                    return (
+                      <div key={idx} className="flex gap-3">
+                        <div className="flex flex-col items-center">
+                          <Icon
+                            className={`w-5 h-5 flex-shrink-0 ${
+                              event.done ? "text-green-500" : "text-gray-300"
+                            }`}
+                          />
+                          {!isLast && (
+                            <div className={`w-0.5 h-8 ${event.done ? "bg-green-200" : "bg-gray-200"}`} />
+                          )}
+                        </div>
+                        <div className="pb-6">
+                          <p className={`text-sm font-medium ${event.done ? "text-gray-900" : "text-gray-400"}`}>
+                            {event.label}
+                          </p>
+                          {event.time && (
+                            <p className="text-xs text-gray-500">{fmtDate(event.time)}</p>
+                          )}
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              </Card>
+
+              {/* Related Order */}
+              {order && (
+                <Card className="p-5">
+                  <h3 className="text-lg font-semibold text-gray-900 mb-3">Related Order</h3>
+                  <div className="space-y-3">
+                    {order.books.map((book, idx) => (
+                      <div key={idx} className="flex items-center gap-3">
+                        {book.coverImgUrl ? (
+                          <img
+                            src={book.coverImgUrl}
+                            alt={book.titleEn}
+                            className="w-12 h-16 object-cover rounded"
+                          />
+                        ) : (
+                          <div className="w-12 h-16 bg-gray-100 rounded flex items-center justify-center text-xs text-gray-400">
+                            No Cover
+                          </div>
+                        )}
+                        <div>
+                          <p className="font-medium text-gray-900">{book.titleEn}</p>
+                          {book.author && <p className="text-sm text-gray-500">{book.author}</p>}
+                        </div>
+                      </div>
+                    ))}
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="mt-2 border-black text-black hover:bg-black hover:text-white"
+                      onClick={() => router.push(`/borrowing/${orderId}`)}
+                    >
+                      <ExternalLink className="w-4 h-4 mr-1" />
+                      View Order Details
+                    </Button>
+                  </div>
+                </Card>
+              )}
+            </div>
+
+            {/* Right Column */}
+            <div className="space-y-6">
+              {/* Refund Breakdown */}
+              <Card className="p-5">
+                <h3 className="text-lg font-semibold text-gray-900 mb-3">Refund Summary</h3>
+                <div className="space-y-2 text-sm">
+                  {order && (
+                    <>
+                      <div className="flex justify-between text-gray-600">
+                        <span>Original Payment</span>
+                        <span>{fmtDollars(order.totalPaidAmount)}</span>
+                      </div>
+                      <div className="flex justify-between text-gray-500 pl-3">
+                        <span>Deposit</span>
+                        <span>{fmtDollars(order.depositOrSaleAmount)}</span>
+                      </div>
+                      <div className="flex justify-between text-gray-500 pl-3">
+                        <span>Shipping Fee</span>
+                        <span>{fmtDollars(order.shippingOutFeeAmount)}</span>
+                      </div>
+                      <div className="flex justify-between text-gray-500 pl-3">
+                        <span>Service Fee</span>
+                        <span>{fmtDollars(order.serviceFeeAmount)}</span>
+                      </div>
+                      <hr className="my-2" />
+                    </>
+                  )}
+                  <div className="flex justify-between font-semibold text-gray-900">
+                    <span>Total Refunded</span>
+                    <span className="text-green-600">
+                      {fmtAmount(primaryRefund.amount, primaryRefund.currency)}
+                    </span>
+                  </div>
+                </div>
+              </Card>
+
+              {/* Refund Info */}
+              <Card className="p-5">
+                <h3 className="text-lg font-semibold text-gray-900 mb-3">Refund Information</h3>
+                <div className="space-y-2 text-sm">
+                  <div className="flex justify-between">
+                    <span className="text-gray-500">Refund ID</span>
+                    <span className="text-gray-900 font-mono text-xs">{primaryRefund.refund_id}</span>
+                  </div>
+                  <div className="flex justify-between">
+                    <span className="text-gray-500">Status</span>
+                    <span className={`font-medium ${statusConfig.className}`}>{statusConfig.label}</span>
+                  </div>
+                  <div className="flex justify-between">
+                    <span className="text-gray-500">Reason</span>
+                    <span className="text-gray-900">{primaryRefund.reason || "N/A"}</span>
+                  </div>
+                  <div className="flex justify-between">
+                    <span className="text-gray-500">Initiated</span>
+                    <span className="text-gray-900">{fmtDate(primaryRefund.created_at)}</span>
+                  </div>
+                  <div className="flex justify-between">
+                    <span className="text-gray-500">Last Updated</span>
+                    <span className="text-gray-900">{fmtDate(primaryRefund.updated_at)}</span>
+                  </div>
+                </div>
+              </Card>
+
+              {/* Multiple refunds for same order */}
+              {refunds.length > 1 && (
+                <Card className="p-5">
+                  <h3 className="text-lg font-semibold text-gray-900 mb-3">
+                    All Refunds ({refunds.length})
+                  </h3>
+                  <div className="space-y-3">
+                    {refunds.map((r) => {
+                      const cfg = STATUS_CONFIG[r.status] || STATUS_CONFIG["pending"];
+                      return (
+                        <div key={r.refund_id} className="flex items-center justify-between py-2 border-b last:border-0">
+                          <div>
+                            <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${cfg.className} ${cfg.bgClassName}`}>
+                              {cfg.label}
+                            </span>
+                            <span className="text-xs text-gray-500 ml-2">{fmtDate(r.created_at)}</span>
+                          </div>
+                          <span className="font-semibold">{fmtAmount(r.amount, r.currency)}</span>
+                        </div>
+                      );
+                    })}
+                  </div>
+                </Card>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontendNext/app/refunds/page.tsx
+++ b/frontendNext/app/refunds/page.tsx
@@ -1,0 +1,285 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import { Search, Filter, RefreshCw, ArrowLeft } from "lucide-react";
+import Card from "../components/ui/Card";
+import Button from "../components/ui/Button";
+import { getUserRefunds } from "@/utils/payments";
+import { getCurrentUser } from "@/utils/auth";
+
+type RefundStatus = "succeeded" | "pending" | "failed";
+
+const STATUS_META: Record<string, { label: string; className: string }> = {
+  succeeded: { label: "Completed", className: "bg-green-100 text-green-700" },
+  pending: { label: "Processing", className: "bg-yellow-100 text-yellow-700" },
+  failed: { label: "Failed", className: "bg-red-100 text-red-700" },
+};
+
+const TYPE_LABELS: Record<string, string> = {
+  full: "Full Refund",
+  deposit: "Deposit Only",
+  shipping: "Shipping Only",
+  partial: "Partial Refund",
+};
+
+interface RefundItem {
+  refund_id: string;
+  amount: number;
+  currency: string;
+  status: string;
+  reason: string | null;
+  refund_type: string;
+  created_at: string | null;
+  updated_at: string | null;
+  order: {
+    order_id: string;
+    status: string;
+    book_titles: string[];
+    created_at: string | null;
+    canceled_at: string | null;
+  };
+  timeline: Array<{
+    event: string;
+    actor: string;
+    message: string;
+    timestamp: string | null;
+  }>;
+}
+
+export default function RefundsPage() {
+  const [refunds, setRefunds] = useState<RefundItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [statusFilter, setStatusFilter] = useState<"all" | RefundStatus>("all");
+  const [search, setSearch] = useState("");
+  const router = useRouter();
+
+  useEffect(() => {
+    const loadRefunds = async () => {
+      try {
+        setLoading(true);
+        const user = await getCurrentUser();
+        if (!user?.id) {
+          setError("Please log in to view your refunds.");
+          return;
+        }
+        const data = await getUserRefunds(user.id);
+        setRefunds(data.refunds);
+      } catch (err) {
+        console.error("Failed to load refunds:", err);
+        setError("Failed to load refunds. Please try again.");
+      } finally {
+        setLoading(false);
+      }
+    };
+    loadRefunds();
+  }, []);
+
+  const filteredRefunds = useMemo(() => {
+    let list = refunds;
+    if (statusFilter !== "all") {
+      list = list.filter((r) => r.status === statusFilter);
+    }
+    if (search) {
+      const q = search.toLowerCase();
+      list = list.filter((r) => {
+        const bookMatch = r.order.book_titles.some((t) =>
+          t.toLowerCase().includes(q)
+        );
+        return (
+          bookMatch ||
+          r.refund_id.toLowerCase().includes(q) ||
+          r.order.order_id.toLowerCase().includes(q) ||
+          (r.reason && r.reason.toLowerCase().includes(q))
+        );
+      });
+    }
+    return list;
+  }, [refunds, statusFilter, search]);
+
+  const countByStatus = (s: RefundStatus) =>
+    refunds.filter((r) => r.status === s).length;
+
+  const filterOptions = [
+    { value: "all", label: "All", count: refunds.length },
+    { value: "pending", label: "Processing", count: countByStatus("pending") },
+    { value: "succeeded", label: "Completed", count: countByStatus("succeeded") },
+    { value: "failed", label: "Failed", count: countByStatus("failed") },
+  ] as const;
+
+  const fmtDate = (v?: string | null) => {
+    if (!v) return "-";
+    try {
+      return new Date(v).toLocaleString();
+    } catch {
+      return "Invalid date";
+    }
+  };
+
+  const fmtAmount = (cents: number, currency: string) => {
+    const dollars = (cents / 100).toFixed(2);
+    const sym = currency.toUpperCase() === "AUD" ? "A$" : "$";
+    return `${sym}${dollars} ${currency.toUpperCase()}`;
+  };
+
+  return (
+    <div className="flex h-full">
+      <div className="flex-1 overflow-y-auto">
+        <div className="max-w-6xl mx-auto p-6">
+          {/* Header */}
+          <div className="mb-8">
+            <button
+              onClick={() => router.back()}
+              className="flex items-center gap-1 text-gray-500 hover:text-black mb-4 text-sm"
+            >
+              <ArrowLeft className="w-4 h-4" /> Back
+            </button>
+            <h1 className="text-3xl font-bold text-gray-900 mb-2">
+              My Refunds
+            </h1>
+            <p className="text-gray-600">
+              Track the status of your refund requests
+            </p>
+          </div>
+
+          {/* Search & Filters */}
+          <div className="mb-6 space-y-4">
+            <div className="flex flex-col sm:flex-row gap-4">
+              <div className="flex-1 relative">
+                <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 w-4 h-4" />
+                <input
+                  type="text"
+                  placeholder="Search by book title, refund ID, or order ID..."
+                  value={search}
+                  onChange={(e) => setSearch(e.target.value)}
+                  className="w-full pl-10 pr-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                />
+              </div>
+            </div>
+
+            <div className="flex flex-wrap gap-2">
+              {filterOptions.map((option) => (
+                <Button
+                  key={option.value}
+                  variant={statusFilter === option.value ? "default" : "outline"}
+                  onClick={() => setStatusFilter(option.value as any)}
+                  className={`flex items-center gap-2 ${
+                    statusFilter === option.value
+                      ? "bg-black text-white hover:bg-gray-800 border-black"
+                      : ""
+                  }`}
+                >
+                  <Filter className="w-4 h-4" />
+                  {option.label}
+                  <span className="bg-white/20 px-2 py-0.5 rounded-full text-xs">
+                    {option.count}
+                  </span>
+                </Button>
+              ))}
+            </div>
+          </div>
+
+          {/* Error / Loading */}
+          {error && (
+            <Card>
+              <div className="p-4 text-red-600">{error}</div>
+            </Card>
+          )}
+          {loading && (
+            <Card>
+              <div className="p-4 text-gray-600">Loading refunds...</div>
+            </Card>
+          )}
+
+          {/* Refund list */}
+          {!loading && !error && (
+            <div className="space-y-4">
+              {filteredRefunds.length === 0 ? (
+                <Card>
+                  <div className="text-center py-12">
+                    <RefreshCw className="w-16 h-16 text-gray-300 mx-auto mb-4" />
+                    <h3 className="text-lg font-medium text-gray-900 mb-2">
+                      No refunds found
+                    </h3>
+                    <p className="text-gray-500">
+                      {refunds.length === 0
+                        ? "You don't have any refund records yet."
+                        : "Try adjusting filters or search terms."}
+                    </p>
+                  </div>
+                </Card>
+              ) : (
+                filteredRefunds.map((refund) => {
+                  const meta = STATUS_META[refund.status] || STATUS_META["pending"];
+                  const bookTitle =
+                    refund.order.book_titles.length > 0
+                      ? refund.order.book_titles.join(", ")
+                      : "Unknown Book";
+
+                  return (
+                    <Card
+                      key={refund.refund_id}
+                      className="p-5 border border-gray-200 rounded-xl hover:shadow-md transition cursor-pointer"
+                      onClick={() => router.push(`/refunds/${refund.order.order_id}`)}
+                    >
+                      <div className="flex items-start justify-between gap-4">
+                        {/* Left: Info */}
+                        <div className="flex-1 min-w-0">
+                          <div className="flex items-center gap-3 mb-2">
+                            <h3 className="text-lg font-semibold text-gray-900 truncate">
+                              {bookTitle}
+                            </h3>
+                            <span
+                              className={`px-2.5 py-0.5 rounded-full text-xs font-medium whitespace-nowrap ${meta.className}`}
+                            >
+                              {meta.label}
+                            </span>
+                          </div>
+
+                          <div className="space-y-1 text-sm text-gray-500">
+                            <div>
+                              <span className="text-gray-400">Reason: </span>
+                              {refund.reason || "N/A"}
+                            </div>
+                            <div>
+                              <span className="text-gray-400">Type: </span>
+                              {TYPE_LABELS[refund.refund_type] || refund.refund_type}
+                            </div>
+                            <div>
+                              <span className="text-gray-400">Order: </span>
+                              <span
+                                className="text-blue-600 hover:underline"
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  router.push(`/borrowing/${refund.order.order_id}`);
+                                }}
+                              >
+                                {refund.order.order_id.slice(0, 8)}...
+                              </span>
+                            </div>
+                            <div>
+                              <span className="text-gray-400">Refunded: </span>
+                              {fmtDate(refund.created_at)}
+                            </div>
+                          </div>
+                        </div>
+
+                        {/* Right: Amount */}
+                        <div className="text-right flex-shrink-0">
+                          <div className="text-2xl font-bold text-gray-900">
+                            {fmtAmount(refund.amount, refund.currency)}
+                          </div>
+                        </div>
+                      </div>
+                    </Card>
+                  );
+                })
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontendNext/utils/payments.ts
+++ b/frontendNext/utils/payments.ts
@@ -202,6 +202,45 @@ export async function cancelOrderWithRefund(orderId: string) {
   };
 }
 
+// MVP6: Get all refunds for a user
+export async function getUserRefunds(userId: string) {
+  const res = await axios.get(
+    `${API_URL}/payment_gateway/refunds/user/${userId}`,
+    {
+      headers: {
+        Authorization: `Bearer ${localStorage.getItem("access_token")}`,
+      },
+      withCredentials: true,
+    }
+  );
+  return res.data as {
+    user_id: string;
+    refunds: Array<{
+      refund_id: string;
+      amount: number;
+      currency: string;
+      status: string;
+      reason: string | null;
+      refund_type: string;
+      created_at: string | null;
+      updated_at: string | null;
+      order: {
+        order_id: string;
+        status: string;
+        book_titles: string[];
+        created_at: string | null;
+        canceled_at: string | null;
+      };
+      timeline: Array<{
+        event: string;
+        actor: string;
+        message: string;
+        timestamp: string | null;
+      }>;
+    }>;
+  };
+}
+
 // Execute compensation transfer after dispute resolved
 export async function compensatePayment(
   paymentId: string,


### PR DESCRIPTION
Add refund tracking pages for end users:

Backend:
- New API: GET /refunds/user/{user_id} (returns user's refunds with order info, book titles, timeline)
- Fix seed.py: add Payment model import, add CANCELED order with refund demo data
- compose.yaml: add MySQL service, expose frontend/backend ports for local dev

Frontend:
- /refunds: refund list page with status filter (All/Processing/Completed/Failed) and search
- /refunds/[id]: refund detail page with timeline, refund summary, related order info
- /borrowing: add "My Refunds" navigation button
- /borrowing/[id]: add "View Refund Details" button in Refund Status section
- New utility: getUserRefunds() in payments.ts


The effectiveness of demos is shown in the figure:

<img width="522" height="602" alt="屏幕截图 2026-04-07 230547" src="https://github.com/user-attachments/assets/e67da508-26d6-4c3d-9db3-63099d961bbf" />

<img width="1636" height="1132" alt="屏幕截图 2026-04-07 230643" src="https://github.com/user-attachments/assets/04351c76-9bc2-4978-a1fa-3050ad08d49e" />

<img width="672" height="653" alt="屏幕截图 2026-04-07 230733" src="https://github.com/user-attachments/assets/dd4fd6f4-7f23-4223-8789-f4e940c84334" />

<img width="1967" height="564" alt="屏幕截图 2026-04-07 230810" src="https://github.com/user-attachments/assets/f85eff47-e54c-41e2-a86d-1fca0edec290" />


