### PR TITLE
feat: add system notifications for all order status changes

### DIFF
--- a/fastapi/main.py
+++ b/fastapi/main.py
@@ -20,6 +20,7 @@ from routes.bans import router as bans_router
 from routes.blacklists import router as blacklists_router
 from routes.review import router as review_router
 from routes.analytics import router as analytics_router  # Import analytics router
+from routes.notifications import router as notifications_router
 
 # update order statuses automatically
 from contextlib import asynccontextmanager
@@ -32,6 +33,7 @@ from seed import seed as seed_sample_data
 import models.user, models.book, models.order, models.cart, models.message
 import models.complaint, models.ban, models.blacklist, models.review
 import models.payment_gateway, models.payment_split, models.mail
+import models.system_notification
 from models.base import Base
 from models.checkout import Base as CheckoutBase
 from models.service_fee import Base as ServiceFeeBase
@@ -129,6 +131,7 @@ app.include_router(blacklists_router, prefix="/api/v1")
 
 #Register the analytics router
 app.include_router(analytics_router, prefix="/api/v1")
+app.include_router(notifications_router, prefix="/api/v1")
 
 @app.get("/")
 async def root():

--- a/fastapi/models/system_notification.py
+++ b/fastapi/models/system_notification.py
@@ -1,0 +1,17 @@
+from sqlalchemy import Column, String, DateTime, Boolean, Text
+from sqlalchemy.sql import func
+from .base import Base
+import uuid
+
+
+class SystemNotification(Base):
+    __tablename__ = "system_notifications"
+
+    id = Column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
+    user_id = Column(String(25), nullable=False, index=True)
+    order_id = Column(String(36), nullable=True)
+    type = Column(String(50), nullable=False)  # e.g. PAYMENT_CONFIRMED, SHIPMENT_SENT, BORROWING, OVERDUE, RETURNED, COMPLETED, CANCELED, REFUND
+    title = Column(String(200), nullable=False)
+    message = Column(Text, nullable=False)
+    is_read = Column(Boolean, default=False, nullable=False)
+    created_at = Column(DateTime, server_default=func.now(), nullable=False)

--- a/fastapi/routes/notifications.py
+++ b/fastapi/routes/notifications.py
@@ -1,0 +1,45 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+from core.dependencies import get_db, get_current_user
+from models.user import User
+from services.notification_service import NotificationService
+
+router = APIRouter(prefix="/notifications", tags=["Notifications"])
+
+
+@router.get("/")
+def list_notifications(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    notifications = NotificationService.get_user_notifications(db, current_user.user_id)
+    return [
+        {
+            "id": n.id,
+            "order_id": n.order_id,
+            "type": n.type,
+            "title": n.title,
+            "message": n.message,
+            "is_read": n.is_read,
+            "created_at": n.created_at.isoformat() if n.created_at else None,
+        }
+        for n in notifications
+    ]
+
+
+@router.get("/unread-count")
+def unread_count(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    count = NotificationService.get_unread_count(db, current_user.user_id)
+    return {"unread_count": count}
+
+
+@router.put("/mark-all-read")
+def mark_all_read(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    count = NotificationService.mark_all_read(db, current_user.user_id)
+    return {"marked": count}

--- a/fastapi/services/notification_service.py
+++ b/fastapi/services/notification_service.py
@@ -1,0 +1,69 @@
+from sqlalchemy.orm import Session
+from models.system_notification import SystemNotification
+from typing import List, Optional
+
+
+class NotificationService:
+
+    @staticmethod
+    def create(
+        db: Session,
+        user_id: str,
+        type: str,
+        title: str,
+        message: str,
+        order_id: Optional[str] = None,
+        commit: bool = True,
+    ) -> SystemNotification:
+        notif = SystemNotification(
+            user_id=user_id,
+            order_id=order_id,
+            type=type,
+            title=title,
+            message=message,
+        )
+        db.add(notif)
+        if commit:
+            db.commit()
+            db.refresh(notif)
+        return notif
+
+    @staticmethod
+    def get_user_notifications(
+        db: Session,
+        user_id: str,
+        skip: int = 0,
+        limit: int = 50,
+    ) -> List[SystemNotification]:
+        return (
+            db.query(SystemNotification)
+            .filter(SystemNotification.user_id == user_id)
+            .order_by(SystemNotification.created_at.desc())
+            .offset(skip)
+            .limit(limit)
+            .all()
+        )
+
+    @staticmethod
+    def get_unread_count(db: Session, user_id: str) -> int:
+        return (
+            db.query(SystemNotification)
+            .filter(
+                SystemNotification.user_id == user_id,
+                SystemNotification.is_read == False,
+            )
+            .count()
+        )
+
+    @staticmethod
+    def mark_all_read(db: Session, user_id: str) -> int:
+        count = (
+            db.query(SystemNotification)
+            .filter(
+                SystemNotification.user_id == user_id,
+                SystemNotification.is_read == False,
+            )
+            .update({"is_read": True})
+        )
+        db.commit()
+        return count

--- a/fastapi/services/order_service.py
+++ b/fastapi/services/order_service.py
@@ -13,6 +13,7 @@ from services.cart_service import remove_cart_items_by_book_ids
 from models.complaint import Complaint
 from sqlalchemy import or_
 from services.complaint_service import ComplaintService
+from services.notification_service import NotificationService
 from typing import Set
 
 class OrderService:
@@ -365,7 +366,23 @@ class OrderService:
         # Update order status to CANCELED
         order.status = "CANCELED"
         order.canceled_at = datetime.now(timezone.utc)
-        
+
+        # Notify both parties
+        NotificationService.create(
+            db, user_id=order.borrower_id, order_id=order.id,
+            type="CANCELED",
+            title="Order Cancelled",
+            message=f"Your order has been cancelled. If payment was made, a refund will be processed.",
+            commit=False,
+        )
+        NotificationService.create(
+            db, user_id=order.owner_id, order_id=order.id,
+            type="CANCELED",
+            title="Order Cancelled",
+            message=f"An order for your book has been cancelled by the borrower.",
+            commit=False,
+        )
+
         # Restore book availability - set books back to 'listed' status
         for order_book in order.books:
             if order_book.book:
@@ -445,6 +462,24 @@ class OrderService:
             )
         
         order.status = "PENDING_SHIPMENT"
+
+        # Notify borrower: payment confirmed
+        NotificationService.create(
+            db, user_id=order.borrower_id, order_id=order.id,
+            type="PAYMENT_CONFIRMED",
+            title="Payment Confirmed",
+            message=f"Your payment of ${float(order.total_paid_amount):.2f} has been confirmed. Waiting for the lender to ship.",
+            commit=False,
+        )
+        # Notify owner: new order received
+        NotificationService.create(
+            db, user_id=order.owner_id, order_id=order.id,
+            type="PAYMENT_CONFIRMED",
+            title="New Order Received",
+            message=f"A borrower has paid for your book. Please ship within 3 days.",
+            commit=False,
+        )
+
         db.commit()
         db.refresh(order)
         return True
@@ -500,6 +535,15 @@ class OrderService:
             )
             order.due_at = order.start_at + timedelta(days=max_lending_days)
 
+            # Notify borrower: book shipped
+            NotificationService.create(
+                db, user_id=order.borrower_id, order_id=order.id,
+                type="SHIPMENT_SENT",
+                title="Book Shipped",
+                message=f"The lender has shipped your book. Tracking: {tracking_number} ({carrier_upper}).",
+                commit=False,
+            )
+
             # implement distribute shipping fee function
             try:
                 payment_id = order.payment_id
@@ -523,6 +567,23 @@ class OrderService:
             # Update status to RETURNED
             order.status = "RETURNED"
             order.returned_at = datetime.now(timezone.utc)
+
+            # Notify owner: book returned
+            NotificationService.create(
+                db, user_id=order.owner_id, order_id=order.id,
+                type="RETURNED",
+                title="Book Returned",
+                message=f"The borrower has shipped your book back. Tracking: {tracking_number} ({carrier_upper}).",
+                commit=False,
+            )
+            # Notify borrower: return confirmed
+            NotificationService.create(
+                db, user_id=order.borrower_id, order_id=order.id,
+                type="RETURNED",
+                title="Return Shipment Confirmed",
+                message=f"Your return shipment has been recorded. Waiting for the lender to confirm receipt.",
+                commit=False,
+            )
                 
         else:
             raise HTTPException(
@@ -555,8 +616,22 @@ class OrderService:
         count = 0
         for order in orders:
             order.status = "BORROWING"
+            NotificationService.create(
+                db, user_id=order.borrower_id, order_id=order.id,
+                type="BORROWING",
+                title="Borrowing Started",
+                message=f"Your book has been delivered. The borrowing period has started. Due date: {order.due_at.strftime('%d/%m/%Y') if order.due_at else 'N/A'}.",
+                commit=False,
+            )
+            NotificationService.create(
+                db, user_id=order.owner_id, order_id=order.id,
+                type="BORROWING",
+                title="Book Delivered",
+                message=f"Your book has been delivered to the borrower. Borrowing period started.",
+                commit=False,
+            )
             count += 1
-        
+
         db.commit()
         return count
 
@@ -613,6 +688,20 @@ class OrderService:
                     )
                     
                 order.status = "OVERDUE"
+                NotificationService.create(
+                    db, user_id=order.borrower_id, order_id=order.id,
+                    type="OVERDUE",
+                    title="Order Overdue",
+                    message=f"Your borrowing order is overdue (due: {order.due_at.strftime('%d/%m/%Y') if order.due_at else 'N/A'}). Please return the book as soon as possible.",
+                    commit=False,
+                )
+                NotificationService.create(
+                    db, user_id=order.owner_id, order_id=order.id,
+                    type="OVERDUE",
+                    title="Order Overdue",
+                    message=f"A borrower has not returned your book on time. A complaint has been filed automatically.",
+                    commit=False,
+                )
                 count += 1
                 
             db.commit()
@@ -648,8 +737,6 @@ class OrderService:
                 order.completed_at = now
 
                 # Restore book availability for borrowed books
-                # For borrow orders: set books back to 'listed'
-                # For purchase orders: books stay as 'sold'
                 if order.action_type == "borrow":
                     for order_book in order.books:
                         if order_book.book:
@@ -657,6 +744,20 @@ class OrderService:
                             if book and book.status == "lent":
                                 book.status = "listed"
 
+                NotificationService.create(
+                    db, user_id=order.borrower_id, order_id=order.id,
+                    type="COMPLETED",
+                    title="Order Completed",
+                    message=f"Your order has been completed. The deposit refund will be processed.",
+                    commit=False,
+                )
+                NotificationService.create(
+                    db, user_id=order.owner_id, order_id=order.id,
+                    type="COMPLETED",
+                    title="Order Completed",
+                    message=f"The borrowing order has been completed. The book has been returned.",
+                    commit=False,
+                )
                 count += 1
 
         db.commit()
@@ -690,6 +791,21 @@ class OrderService:
                     book = db.query(Book).filter(Book.id == order_book.book_id).first()
                     if book and book.status == "lent":
                         book.status = "listed"
+
+        NotificationService.create(
+            db, user_id=order.borrower_id, order_id=order.id,
+            type="COMPLETED",
+            title="Order Completed",
+            message=f"The lender has confirmed receipt of the returned book. Your deposit refund will be processed.",
+            commit=False,
+        )
+        NotificationService.create(
+            db, user_id=order.owner_id, order_id=order.id,
+            type="COMPLETED",
+            title="Order Completed",
+            message=f"You have confirmed receipt of the returned book. Order is now complete.",
+            commit=False,
+        )
 
         db.commit()
         db.refresh(order)

--- a/fastapi/services/payment_gateway_service.py
+++ b/fastapi/services/payment_gateway_service.py
@@ -390,6 +390,23 @@ def refund_payment(payment_id: str, data: dict, *, db: Session):
         else:
             payment.status = "partially_refunded"
 
+        # 3.5 Send refund notification to the borrower
+        try:
+            from models.order import Order
+            from services.notification_service import NotificationService
+            order = db.query(Order).filter(Order.payment_id == payment_id).first()
+            if order:
+                amount_display = refund.amount / 100
+                NotificationService.create(
+                    db, user_id=order.borrower_id, order_id=order.id,
+                    type="REFUND",
+                    title="Refund Completed" if refund.status in ("succeeded", "refunded") else "Refund Processing",
+                    message=f"Refund of ${amount_display:.2f} {refund.currency.upper()} has been {'completed' if refund.status in ('succeeded', 'refunded') else 'initiated'}.",
+                    commit=False,
+                )
+        except Exception as e:
+            print(f"[WARN] Failed to create refund notification: {e}")
+
         db.commit()
 
         # 4. Return refund details

--- a/frontendNext/app/components/layout/Header.tsx
+++ b/frontendNext/app/components/layout/Header.tsx
@@ -10,7 +10,6 @@ import { isProfileComplete } from "@/utils/profileValidation";
 
 import { User as UserIcon, LogOut, Plus, Truck, Mail, LifeBuoy, ShoppingBag, ShieldCheck } from "lucide-react";
 import { logoutUser, isAuthenticated, getCurrentUser, getApiUrl, getToken } from "@/utils/auth";
-import { getRefundsForOrder } from "@/utils/payments";
 
 import Avatar from "@/app/components/ui/Avatar";
 import { useCartStore } from "@/app/store/cartStore";
@@ -118,38 +117,17 @@ const Header: React.FC = () => {
     router.push("/register");
   };
 
-  // Fetch system notification count (new refunds since last viewed)
+  // Fetch system notification count from notifications API
   const fetchSystemNotifCount = async () => {
     try {
       const apiUrl = getApiUrl();
       const token = getToken();
-      const lastSeen = localStorage.getItem("notif_last_seen") || "0";
-
-      const res = await fetch(`${apiUrl}/api/v1/orders/?status=CANCELED`, {
+      const res = await fetch(`${apiUrl}/api/v1/notifications/unread-count`, {
         headers: { Authorization: `Bearer ${token}` },
       });
       if (!res.ok) return;
-
       const data = await res.json();
-      const orders = Array.isArray(data) ? data : (data.value || data.items || []);
-
-      let count = 0;
-      for (const order of orders) {
-        const oid = order.order_id || order.id;
-        try {
-          const refundData = await getRefundsForOrder(oid);
-          if (refundData.refunds) {
-            for (const r of refundData.refunds) {
-              if (new Date(r.created_at).getTime() > Number(lastSeen)) {
-                count++;
-              }
-            }
-          }
-        } catch {
-          // skip
-        }
-      }
-      setSystemNotifCount(count);
+      setSystemNotifCount(data.unread_count || 0);
     } catch {
       // silent fail
     }

--- a/frontendNext/app/message/page.tsx
+++ b/frontendNext/app/message/page.tsx
@@ -17,24 +17,19 @@ import {
   sendMessageWithImage,
   getUserByEmail,
 } from "@/utils/messageApi";
-import { getRefundsForOrder } from "@/utils/payments";
 
 const API_URL = getApiUrl();
 const WS_URL = process.env.NEXT_PUBLIC_WS_URL || "ws://localhost:8000";
 
 // ── Types ──────────────────────────────────────────────────────
-interface OrderWithRefunds {
-  orderId: string;
-  status: string;
-  canceledAt: string | null;
-  refunds: Array<{
-    refund_id: string;
-    amount: number;
-    currency: string;
-    status: string;
-    reason: string | null;
-    created_at: string;
-  }>;
+interface SystemNotification {
+  id: string;
+  order_id: string | null;
+  type: string;
+  title: string;
+  message: string;
+  is_read: boolean;
+  created_at: string;
 }
 
 type ViewTab = "personal" | "system";
@@ -60,6 +55,69 @@ const formatTimeAgo = (dateStr: string) => {
   return `${days} days ago`;
 };
 
+const NOTIF_ICON_MAP: Record<string, { bg: string; color: string; icon: JSX.Element }> = {
+  PAYMENT_CONFIRMED: {
+    bg: "bg-green-100", color: "text-green-700",
+    icon: <svg xmlns="http://www.w3.org/2000/svg" className="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><polyline points="20 6 9 17 4 12"/></svg>,
+  },
+  SHIPMENT_SENT: {
+    bg: "bg-blue-100", color: "text-blue-700",
+    icon: <svg xmlns="http://www.w3.org/2000/svg" className="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><rect x="1" y="3" width="15" height="13"/><polygon points="16 8 20 8 23 11 23 16 16 16 16 8"/><circle cx="5.5" cy="18.5" r="2.5"/><circle cx="18.5" cy="18.5" r="2.5"/></svg>,
+  },
+  BORROWING: {
+    bg: "bg-indigo-100", color: "text-indigo-700",
+    icon: <svg xmlns="http://www.w3.org/2000/svg" className="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>,
+  },
+  OVERDUE: {
+    bg: "bg-red-100", color: "text-red-600",
+    icon: <svg xmlns="http://www.w3.org/2000/svg" className="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>,
+  },
+  RETURNED: {
+    bg: "bg-purple-100", color: "text-purple-700",
+    icon: <svg xmlns="http://www.w3.org/2000/svg" className="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polyline points="1 4 1 10 7 10"/><path d="M3.51 15a9 9 0 1 0 2.13-9.36L1 10"/></svg>,
+  },
+  COMPLETED: {
+    bg: "bg-green-100", color: "text-green-700",
+    icon: <svg xmlns="http://www.w3.org/2000/svg" className="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/></svg>,
+  },
+  CANCELED: {
+    bg: "bg-gray-200", color: "text-gray-600",
+    icon: <svg xmlns="http://www.w3.org/2000/svg" className="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><circle cx="12" cy="12" r="10"/><line x1="15" y1="9" x2="9" y2="15"/><line x1="9" y1="9" x2="15" y2="15"/></svg>,
+  },
+  REFUND: {
+    bg: "bg-amber-100", color: "text-amber-700",
+    icon: <svg xmlns="http://www.w3.org/2000/svg" className="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><line x1="12" y1="1" x2="12" y2="23"/><path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"/></svg>,
+  },
+};
+
+const getNotifIcon = (type: string) => {
+  const config = NOTIF_ICON_MAP[type] || NOTIF_ICON_MAP.COMPLETED;
+  return (
+    <div className={`w-10 h-10 rounded-full ${config.bg} flex items-center justify-center shrink-0 ${config.color}`}>
+      {config.icon}
+    </div>
+  );
+};
+
+const getStatusBadge = (type: string) => {
+  const map: Record<string, { bg: string; text: string; label: string }> = {
+    PAYMENT_CONFIRMED: { bg: "bg-green-100", text: "text-green-800", label: "Payment" },
+    SHIPMENT_SENT: { bg: "bg-blue-100", text: "text-blue-800", label: "Shipped" },
+    BORROWING: { bg: "bg-indigo-100", text: "text-indigo-800", label: "Borrowing" },
+    OVERDUE: { bg: "bg-red-100", text: "text-red-800", label: "Overdue" },
+    RETURNED: { bg: "bg-purple-100", text: "text-purple-800", label: "Returned" },
+    COMPLETED: { bg: "bg-green-100", text: "text-green-800", label: "Completed" },
+    CANCELED: { bg: "bg-gray-100", text: "text-gray-800", label: "Cancelled" },
+    REFUND: { bg: "bg-amber-100", text: "text-amber-800", label: "Refund" },
+  };
+  const config = map[type] || { bg: "bg-gray-100", text: "text-gray-800", label: type };
+  return (
+    <span className={`text-[10px] font-bold px-3 py-1 rounded-full uppercase tracking-wider ${config.bg} ${config.text}`}>
+      {config.label}
+    </span>
+  );
+};
+
 // ── Component ──────────────────────────────────────────────────
 export default function MessagesPage() {
   const router = useRouter();
@@ -83,9 +141,8 @@ export default function MessagesPage() {
   const selectedThreadRef = useRef<ChatThread | null>(null);
 
   // ── System Notifications state ──
-  const [notifications, setNotifications] = useState<OrderWithRefunds[]>([]);
-  const [selectedNotification, setSelectedNotification] =
-    useState<OrderWithRefunds | null>(null);
+  const [notifications, setNotifications] = useState<SystemNotification[]>([]);
+  const [selectedNotification, setSelectedNotification] = useState<SystemNotification | null>(null);
   const [notifLoading, setNotifLoading] = useState(false);
   const [systemNotifCount, setSystemNotifCount] = useState(0);
 
@@ -160,73 +217,38 @@ export default function MessagesPage() {
   // ── Load system notifications ──
   useEffect(() => {
     if (activeTab === "system") {
-      loadRefundNotifications();
+      loadSystemNotifications();
     }
   }, [activeTab]);
 
-  const loadRefundNotifications = async () => {
+  const loadSystemNotifications = async () => {
     setNotifLoading(true);
     try {
       const apiUrl = getApiUrl();
       const token = getToken();
 
-      const res = await fetch(`${apiUrl}/api/v1/orders/?status=CANCELED`, {
+      const res = await fetch(`${apiUrl}/api/v1/notifications/`, {
         headers: { Authorization: `Bearer ${token}` },
       });
 
-      let orders: any[] = [];
-      if (res.ok) {
-        const data = await res.json();
-        orders = Array.isArray(data) ? data : data.value || data.items || [];
+      if (!res.ok) throw new Error("Failed to load notifications");
+
+      const data: SystemNotification[] = await res.json();
+      setNotifications(data);
+      if (data.length > 0) {
+        setSelectedNotification(data[0]);
       }
 
-      const resCompleted = await fetch(`${apiUrl}/api/v1/orders/?status=COMPLETED`, {
+      // Mark all as read
+      await fetch(`${apiUrl}/api/v1/notifications/mark-all-read`, {
+        method: "PUT",
         headers: { Authorization: `Bearer ${token}` },
       });
-      if (resCompleted.ok) {
-        const data = await resCompleted.json();
-        const completedOrders = Array.isArray(data)
-          ? data
-          : data.value || data.items || [];
-        orders = [...orders, ...completedOrders];
-      }
 
-      const ordersWithRefunds: OrderWithRefunds[] = [];
-      for (const order of orders) {
-        const oid = order.order_id || order.id;
-        try {
-          const refundData = await getRefundsForOrder(oid);
-          if (refundData.refunds && refundData.refunds.length > 0) {
-            ordersWithRefunds.push({
-              orderId: oid,
-              status: order.status,
-              canceledAt: order.canceledAt || order.canceled_at,
-              refunds: refundData.refunds,
-            });
-          }
-        } catch {
-          // skip
-        }
-      }
-
-      ordersWithRefunds.sort((a, b) => {
-        const aTime = new Date(a.refunds[0]?.created_at || 0).getTime();
-        const bTime = new Date(b.refunds[0]?.created_at || 0).getTime();
-        return bTime - aTime;
-      });
-
-      setNotifications(ordersWithRefunds);
-      if (ordersWithRefunds.length > 0) {
-        setSelectedNotification(ordersWithRefunds[0]);
-      }
-
-      // Mark as seen — save current timestamp
-      localStorage.setItem("notif_last_seen", String(Date.now()));
       setSystemNotifCount(0);
-      // Notify Header to clear badge
       window.dispatchEvent(new Event("notif-read"));
     } catch (error) {
-      console.error("Failed to load refund notifications:", error);
+      console.error("Failed to load system notifications:", error);
     } finally {
       setNotifLoading(false);
     }
@@ -235,42 +257,20 @@ export default function MessagesPage() {
   // ── Compute unseen notification count for sidebar badge ──
   useEffect(() => {
     if (activeTab === "personal") {
-      // Compute in background for sidebar badge
       computeUnseenCount();
     }
-  }, [threads]); // re-run when chat data loads (indicates page is ready)
+  }, [threads]);
 
   const computeUnseenCount = async () => {
     try {
       const apiUrl = getApiUrl();
       const token = getToken();
-      const lastSeen = localStorage.getItem("notif_last_seen") || "0";
-
-      const res = await fetch(`${apiUrl}/api/v1/orders/?status=CANCELED`, {
+      const res = await fetch(`${apiUrl}/api/v1/notifications/unread-count`, {
         headers: { Authorization: `Bearer ${token}` },
       });
       if (!res.ok) return;
-
       const data = await res.json();
-      const orders = Array.isArray(data) ? data : data.value || data.items || [];
-
-      let count = 0;
-      for (const order of orders) {
-        const oid = order.order_id || order.id;
-        try {
-          const refundData = await getRefundsForOrder(oid);
-          if (refundData.refunds) {
-            for (const r of refundData.refunds) {
-              if (new Date(r.created_at).getTime() > Number(lastSeen)) {
-                count++;
-              }
-            }
-          }
-        } catch {
-          // skip
-        }
-      }
-      setSystemNotifCount(count);
+      setSystemNotifCount(data.unread_count || 0);
     } catch {
       // silent
     }
@@ -479,49 +479,8 @@ export default function MessagesPage() {
   // ── Tab switch handler ──
   const switchTab = (tab: ViewTab) => {
     setActiveTab(tab);
-    // Update URL without full reload
     const url = tab === "system" ? "/message?tab=system" : "/message";
     window.history.replaceState(null, "", url);
-  };
-
-  // ── Notification helpers ──
-  const getRefundStatusIcon = (status: string) => {
-    if (status === "succeeded" || status === "refunded") {
-      return (
-        <div className="w-10 h-10 rounded-full bg-green-100 flex items-center justify-center shrink-0">
-          <svg xmlns="http://www.w3.org/2000/svg" className="w-5 h-5 text-green-700" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
-        </div>
-      );
-    }
-    if (status === "failed") {
-      return (
-        <div className="w-10 h-10 rounded-full bg-red-100 flex items-center justify-center shrink-0">
-          <svg xmlns="http://www.w3.org/2000/svg" className="w-5 h-5 text-red-600" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><circle cx="12" cy="12" r="10"/><line x1="15" y1="9" x2="9" y2="15"/><line x1="9" y1="9" x2="15" y2="15"/></svg>
-        </div>
-      );
-    }
-    return (
-      <div className="w-10 h-10 rounded-full bg-amber-100 flex items-center justify-center shrink-0">
-        <svg xmlns="http://www.w3.org/2000/svg" className="w-5 h-5 text-amber-600" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
-      </div>
-    );
-  };
-
-  const getNotificationTitle = (item: OrderWithRefunds) => {
-    const r = item.refunds[0];
-    if (r.status === "succeeded" || r.status === "refunded") return "Refund Completed";
-    if (r.status === "failed") return "Refund Failed";
-    return "Refund Processing";
-  };
-
-  const getNotificationMessage = (item: OrderWithRefunds) => {
-    const r = item.refunds[0];
-    const amount = (r.amount / 100).toFixed(2);
-    if (r.status === "succeeded" || r.status === "refunded")
-      return `Refund of $${amount} completed successfully to your original payment.`;
-    if (r.status === "failed")
-      return `Refund of $${amount} failed. Please contact support.`;
-    return `Your refund of $${amount} is being processed by our system.`;
   };
 
   // ── Loading ──
@@ -754,96 +713,45 @@ export default function MessagesPage() {
                 </div>
               ) : notifications.length === 0 ? (
                 <div className="p-8 text-center text-gray-400 text-sm">
-                  No refund notifications yet
+                  No system notifications yet
                 </div>
               ) : (
                 notifications.map((item) => {
-                  const latestRefund = item.refunds[0];
-                  const isSelected = selectedNotification?.orderId === item.orderId;
-                  const isProcessing = latestRefund.status === "pending";
+                  const isSelected = selectedNotification?.id === item.id;
                   return (
                     <div
-                      key={item.orderId}
+                      key={item.id}
                       onClick={() => setSelectedNotification(item)}
-                      className={`p-5 border-b border-gray-100 cursor-pointer transition-colors relative ${
-                        isSelected ? "bg-white" : "hover:bg-gray-50"
-                      } ${isProcessing ? "bg-white" : "opacity-80"}`}
+                      className={`p-5 border-b border-gray-100 cursor-pointer transition-colors ${
+                        isSelected ? "bg-gray-50" : "hover:bg-gray-50"
+                      } ${!item.is_read ? "bg-white" : "opacity-80"}`}
                     >
-                      {isProcessing && (
+                      {!item.is_read && (
                         <div className="absolute left-0 top-0 bottom-0 w-1 bg-orange-500" />
                       )}
                       <div className="flex gap-3">
-                        {getRefundStatusIcon(latestRefund.status)}
+                        {getNotifIcon(item.type)}
                         <div className="flex-1 min-w-0">
                           <div className="flex justify-between items-start mb-1">
                             <span className="text-[10px] font-bold text-orange-600 uppercase tracking-widest">
                               System
                             </span>
                             <span className="text-[10px] text-gray-400">
-                              {formatTimeAgo(latestRefund.created_at)}
+                              {item.created_at ? formatTimeAgo(item.created_at) : ""}
                             </span>
                           </div>
                           <h3 className="text-sm font-semibold text-gray-900 truncate">
-                            {getNotificationTitle(item)}
+                            {item.title}
                           </h3>
                           <p className="text-sm text-gray-500 line-clamp-2 mt-1">
-                            {getNotificationMessage(item)}
+                            {item.message}
                           </p>
-                          {isProcessing && (
-                            <div className="mt-2 flex items-center gap-2">
-                              <span className="w-2 h-2 rounded-full bg-orange-500 animate-pulse" />
-                              <span className="text-[10px] font-bold text-amber-700">
-                                Pending Authorization
-                              </span>
-                            </div>
-                          )}
-                          {(latestRefund.status === "succeeded" ||
-                            latestRefund.status === "refunded") && (
-                            <div className="mt-2 flex items-center gap-2">
-                              <span className="w-2 h-2 rounded-full bg-green-500" />
-                              <span className="text-[10px] font-bold text-green-700">
-                                Funds Released
-                              </span>
-                            </div>
-                          )}
                         </div>
                       </div>
                     </div>
                   );
                 })
               )}
-
-              {/* Auto-cancel entries */}
-              {notifications
-                .filter((n) => n.status === "CANCELED")
-                .map((item) => (
-                  <div
-                    key={`cancel-${item.orderId}`}
-                    className="p-5 border-b border-gray-100 opacity-70"
-                  >
-                    <div className="flex gap-3">
-                      <div className="w-10 h-10 rounded-full bg-gray-200 flex items-center justify-center shrink-0">
-                        <svg xmlns="http://www.w3.org/2000/svg" className="w-5 h-5 text-gray-600" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><rect x="3" y="3" width="18" height="18" rx="2" ry="2"/><line x1="9" y1="9" x2="15" y2="15"/><line x1="15" y1="9" x2="9" y2="15"/></svg>
-                      </div>
-                      <div className="flex-1 min-w-0">
-                        <div className="flex justify-between items-start mb-1">
-                          <span className="text-[10px] font-bold text-gray-500 uppercase tracking-widest">
-                            System
-                          </span>
-                          <span className="text-[10px] text-gray-400">
-                            {item.canceledAt ? formatTimeAgo(item.canceledAt) : ""}
-                          </span>
-                        </div>
-                        <h3 className="text-sm font-semibold text-gray-900 truncate">
-                          Order auto-cancelled
-                        </h3>
-                        <p className="text-sm text-gray-500 line-clamp-2 mt-1">
-                          The lender did not ship within the required 3 days.
-                        </p>
-                      </div>
-                    </div>
-                  </div>
-                ))}
             </div>
           </section>
 
@@ -859,106 +767,75 @@ export default function MessagesPage() {
                       </div>
                       <div>
                         <h1 className="font-bold text-xl leading-tight">System Message</h1>
-                        <p className="text-xs text-gray-400">
-                          Order: {selectedNotification.orderId.slice(0, 16)}...
-                        </p>
+                        {selectedNotification.order_id && (
+                          <p className="text-xs text-gray-400">
+                            Order: {selectedNotification.order_id.slice(0, 16)}...
+                          </p>
+                        )}
                       </div>
                     </div>
-                    <span
-                      className={`text-[10px] font-bold px-3 py-1 rounded-full uppercase tracking-wider ${
-                        selectedNotification.refunds[0].status === "succeeded" ||
-                        selectedNotification.refunds[0].status === "refunded"
-                          ? "bg-green-100 text-green-800"
-                          : selectedNotification.refunds[0].status === "failed"
-                          ? "bg-red-100 text-red-800"
-                          : "bg-amber-100 text-amber-800"
-                      }`}
-                    >
-                      {selectedNotification.refunds[0].status === "succeeded" ||
-                      selectedNotification.refunds[0].status === "refunded"
-                        ? "Completed"
-                        : selectedNotification.refunds[0].status === "failed"
-                        ? "Failed"
-                        : "Processing"}
-                    </span>
+                    {getStatusBadge(selectedNotification.type)}
                   </div>
 
                   <div className="space-y-6">
-                    <div
-                      className={`p-6 rounded-xl border-l-4 ${
-                        selectedNotification.refunds[0].status === "failed"
-                          ? "bg-red-50 border-red-500"
-                          : "bg-gray-50 border-orange-500"
-                      }`}
-                    >
-                      <p className="text-sm leading-relaxed text-gray-700 font-medium">
-                        {getNotificationMessage(selectedNotification)}
+                    <div className="p-6 rounded-xl border-l-4 bg-gray-50 border-orange-500">
+                      <h3 className="text-base font-bold text-gray-900 mb-2">
+                        {selectedNotification.title}
+                      </h3>
+                      <p className="text-sm leading-relaxed text-gray-700">
+                        {selectedNotification.message}
                       </p>
                     </div>
 
-                    <div className="space-y-4">
+                    <div className="space-y-2">
                       <h4 className="text-xs font-bold text-gray-400 uppercase tracking-widest">
-                        Timeline
+                        Details
                       </h4>
-                      <div className="relative pl-6 space-y-6 before:content-[''] before:absolute before:left-0 before:top-2 before:bottom-2 before:w-[2px] before:bg-gray-200">
-                        {selectedNotification.refunds.map((refund) => (
-                          <div key={refund.refund_id} className="relative">
-                            <div
-                              className={`absolute -left-[27px] top-1 w-3 h-3 rounded-full ring-4 ring-white ${
-                                refund.status === "succeeded" || refund.status === "refunded"
-                                  ? "bg-green-500"
-                                  : refund.status === "failed"
-                                  ? "bg-red-500"
-                                  : "bg-orange-500"
-                              }`}
-                            />
-                            <p className="text-xs font-bold text-gray-900">
-                              {refund.status === "succeeded" || refund.status === "refunded"
-                                ? "Refund Completed"
-                                : refund.status === "failed"
-                                ? "Refund Failed"
-                                : "Refund Initiated"}
-                              {" - "}${(refund.amount / 100).toFixed(2)}{" "}
-                              {refund.currency.toUpperCase()}
-                            </p>
-                            <p className="text-[11px] text-gray-500">
-                              {new Date(refund.created_at).toLocaleString()}
-                            </p>
-                            {refund.reason && (
-                              <p className="text-[11px] text-gray-400 mt-1">{refund.reason}</p>
-                            )}
-                          </div>
-                        ))}
+                      <div className="text-sm text-gray-600 space-y-1">
+                        <p>
+                          <span className="font-medium text-gray-900">Type:</span>{" "}
+                          {selectedNotification.type.replace(/_/g, " ")}
+                        </p>
+                        <p>
+                          <span className="font-medium text-gray-900">Time:</span>{" "}
+                          {selectedNotification.created_at
+                            ? new Date(selectedNotification.created_at).toLocaleString("en-AU", {
+                                timeZone: "Australia/Perth",
+                              })
+                            : "N/A"}
+                        </p>
                       </div>
                     </div>
 
-                    <div className="pt-8 flex flex-col gap-3">
-                      <button
-                        onClick={() =>
-                          router.push(`/borrowing/${selectedNotification.orderId}`)
-                        }
-                        className="w-full py-4 bg-black text-white font-bold rounded-xl text-sm transition-transform hover:scale-[1.02] active:scale-95"
-                      >
-                        View Order Details
-                      </button>
-                      <button
-                        onClick={() =>
-                          router.push(
-                            `/complain?orderId=${selectedNotification.orderId}`
-                          )
-                        }
-                        className="w-full py-4 bg-gray-200 text-gray-900 font-bold rounded-xl text-sm hover:bg-gray-300 transition-colors"
-                      >
-                        Contact Support
-                      </button>
-                    </div>
+                    {selectedNotification.order_id && (
+                      <div className="pt-8 flex flex-col gap-3">
+                        <button
+                          onClick={() =>
+                            router.push(`/borrowing/${selectedNotification.order_id}`)
+                          }
+                          className="w-full py-4 bg-black text-white font-bold rounded-xl text-sm transition-transform hover:scale-[1.02] active:scale-95"
+                        >
+                          View Order Details
+                        </button>
+                        <button
+                          onClick={() =>
+                            router.push(
+                              `/complain?orderId=${selectedNotification.order_id}`
+                            )
+                          }
+                          className="w-full py-4 bg-gray-200 text-gray-900 font-bold rounded-xl text-sm hover:bg-gray-300 transition-colors"
+                        >
+                          Contact Support
+                        </button>
+                      </div>
+                    )}
                   </div>
                 </div>
               </div>
             ) : (
               <div className="flex-1 flex items-center justify-center h-full text-gray-400">
                 {notifications.length === 0
-                  ? "No refund notifications to display"
+                  ? "No system notifications to display"
                   : "Select a notification to view details"}
               </div>
             )}


### PR DESCRIPTION
- Add SystemNotification model, service, and API endpoints
- Trigger notifications on all 7 status transitions + refund
- Both borrower and owner receive notifications
- Update frontend System Notifications tab to use new API
- Update Header badge to use notifications/unread-count API

The effective images are like these:

[
<img width="1932" height="1274" alt="屏幕截图 2026-04-12 212031" src="https://github.com/user-attachments/assets/ec98dab5-d764-473a-8c8e-34e774525e77" />
](url)

It includes these conditions:

RETURNED notification (Alice returns overdue book)

COMPLETED notification (owner confirms receipt)

CANCELED notification (cancel a PENDING order)

PAYMENT_CONFIRMED notification

SHIPMENT_SENT notification (owner ships book)

OVERDUE notification (scheduler triggers)

BORROWING notification (scheduler triggers)