### PR TITLE
Fix duplicate env_file key issue in compose.dev.yaml

### DIFF
--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -48,8 +48,6 @@ services:
       - backend
     networks:
       - mynetwork
-    env_file:
-      - ./.env
 
   nginx:
     image: nginx:latest


### PR DESCRIPTION
### Description

This PR fixes a Docker Compose configuration error in `compose.dev.yaml`.

### Issue

The application failed to start with the following error:

yaml: construct errors:
mapping key "env_file" already defined

This occurred because the `env_file` key was defined twice within the same service block, which is invalid in YAML.

### Root Cause

In YAML, keys must be unique within the same mapping. Defining the same key multiple times causes parsing errors and prevents Docker Compose from running.

Example of incorrect configuration:

backend:
  build: ./fastapi
  env_file:
    - ./.env
  ports:
    - "8000:8000"
  env_file:
    - ./.env

### Fix

Removed the duplicate `env_file` entry and kept a single valid definition.

### Result

- Docker Compose runs successfully
- Backend starts without errors

### Testing

Tested locally using:
docker compose -f compose.yaml -f compose.dev.yaml up --build