### PR TITLE
Authorisation Enhancement

### DIFF
--- a/frontendNext/app/admin/complaints/page.tsx
+++ b/frontendNext/app/admin/complaints/page.tsx
@@ -6,9 +6,8 @@ import { CheckCircle2, CircleX, Clock3, MessageSquareWarning } from "lucide-reac
 import { getCurrentUser } from "@/utils/auth";
 import { getComplaints, resolveComplaint, type Complaint } from "@/utils/complaints";
 
-function isAdminLikeUser(user: { email?: string; is_admin?: boolean } | null) {
-  if (!user) return false;
-  return Boolean(user.is_admin) || Boolean(user.email?.toLowerCase().includes("admin"));
+function isAdminLikeUser(user: { is_admin?: boolean } | null) {
+  return Boolean(user?.is_admin);
 }
 
 export default function AdminComplaintsPage() {

--- a/frontendNext/app/admin/users/page.tsx
+++ b/frontendNext/app/admin/users/page.tsx
@@ -12,9 +12,8 @@ type LookupResult = {
   isAdmin?: boolean;
 };
 
-function isAdminLikeUser(user: { email?: string; is_admin?: boolean } | null) {
-  if (!user) return false;
-  return Boolean(user.is_admin) || Boolean(user.email?.toLowerCase().includes("admin"));
+function isAdminLikeUser(user: { is_admin?: boolean } | null) {
+  return Boolean(user?.is_admin);
 }
 
 export default function AdminUsersPage() {


### PR DESCRIPTION
User could get admin authentication when their username or email including "admin" in the past. Now it only happens when boolean variable return "is_admin" = 1.