### PR TITLE
feat(admin-refund): Admin Refund Management Pages (MVP6 Phase 3)

### DIFF
--- a/fastapi/routes/payment_gateway.py
+++ b/fastapi/routes/payment_gateway.py
@@ -1,11 +1,11 @@
 import os
 import stripe
 import traceback
-from fastapi import APIRouter, Depends, HTTPException, status, Request, Header, Body
+from fastapi import APIRouter, Depends, HTTPException, status, Request, Header, Body, Query
 from core.config import settings
 from services import payment_gateway_service
 from sqlalchemy.orm import Session
-from core.dependencies import get_db
+from core.dependencies import get_db, get_current_admin
 from models.payment_gateway import (
     PaymentInitiateRequest,
     PaymentStatusResponse,
@@ -274,6 +274,521 @@ def get_user_refunds(user_id: str, db: Session = Depends(get_db)):
     # Sort by newest first
     result.sort(key=lambda x: x["created_at"] or "", reverse=True)
     return {"user_id": user_id, "refunds": result}
+
+
+# ---------------------------
+# MVP6 Phase 3: Admin Refund Endpoints
+# ---------------------------
+
+@router.get("/refunds/admin", status_code=status.HTTP_200_OK)
+def get_admin_refunds(
+    status_filter: Optional[str] = Query(None, description="Filter by status: succeeded/pending/failed"),
+    refund_type: Optional[str] = Query(None, description="Filter by type: full/deposit/shipping/partial"),
+    search: Optional[str] = Query(None, description="Search by book title, user name, order ID, or refund ID"),
+    sort_by: Optional[str] = Query("created_at", description="Sort field: created_at/amount"),
+    sort_order: Optional[str] = Query("desc", description="Sort order: asc/desc"),
+    page: int = Query(1, ge=1, description="Page number"),
+    page_size: int = Query(20, ge=1, le=100, description="Items per page"),
+    admin: "User" = Depends(get_current_admin),
+    db: Session = Depends(get_db),
+):
+    """
+    Admin-only: Get all refund records across all users with search, filter, sort, and pagination.
+    Also returns KPI summary (total count, total amount, success rate, failed count).
+    """
+    from models.order import Order, OrderBook
+    from models.payment_split import PaymentSplit
+    from models.payment_gateway import Refund, Payment, AuditLog, Dispute
+    from models.book import Book
+    from models.user import User
+    from sqlalchemy import func as sa_func, or_, cast, String
+
+    # --- KPI Stats ---
+    total_count = db.query(sa_func.count(Refund.id)).scalar() or 0
+    total_amount = db.query(sa_func.coalesce(sa_func.sum(Refund.amount), 0)).scalar() or 0
+    succeeded_count = db.query(sa_func.count(Refund.id)).filter(Refund.status == "succeeded").scalar() or 0
+    failed_count = db.query(sa_func.count(Refund.id)).filter(Refund.status == "failed").scalar() or 0
+    pending_count = db.query(sa_func.count(Refund.id)).filter(Refund.status == "pending").scalar() or 0
+    success_rate = round((succeeded_count / total_count * 100), 1) if total_count > 0 else 0
+
+    # --- Build query ---
+    query = db.query(Refund).join(Payment, Refund.payment_id == Payment.payment_id)
+
+    # Status filter
+    if status_filter:
+        query = query.filter(Refund.status == status_filter)
+
+    # Search
+    if search:
+        search_term = f"%{search}%"
+        # We need to join more tables for search
+        query = query.outerjoin(
+            PaymentSplit, Payment.payment_id == PaymentSplit.payment_id
+        ).outerjoin(
+            Order, PaymentSplit.order_id == Order.id
+        ).outerjoin(
+            User, Order.borrower_id == User.user_id
+        )
+        query = query.filter(
+            or_(
+                Refund.refund_id.ilike(search_term),
+                Order.id.ilike(search_term),
+                User.name.ilike(search_term),
+                User.email.ilike(search_term),
+            )
+        )
+
+    # Sort
+    if sort_by == "amount":
+        order_col = Refund.amount
+    else:
+        order_col = Refund.created_at
+    if sort_order == "asc":
+        query = query.order_by(order_col.asc())
+    else:
+        query = query.order_by(order_col.desc())
+
+    # Pagination
+    total_filtered = query.count()
+    refunds = query.offset((page - 1) * page_size).limit(page_size).all()
+
+    # --- Build response ---
+    result = []
+    for r in refunds:
+        payment = db.query(Payment).filter(Payment.payment_id == r.payment_id).first()
+
+        # Find order via PaymentSplit
+        sp = db.query(PaymentSplit).filter(PaymentSplit.payment_id == r.payment_id).first()
+        order = None
+        borrower = None
+        lender = None
+        book_titles = []
+        disputes = []
+
+        if sp:
+            order = db.query(Order).filter(Order.id == sp.order_id).first()
+            if order:
+                borrower = db.query(User).filter(User.user_id == order.borrower_id).first()
+                lender = db.query(User).filter(User.user_id == order.owner_id).first()
+                order_books = db.query(OrderBook).filter(OrderBook.order_id == order.id).all()
+                for ob in order_books:
+                    book = db.query(Book).filter(Book.id == ob.book_id).first()
+                    if book:
+                        book_titles.append(book.title_en or book.title_or or "Unknown")
+
+        # Determine refund type
+        if sp:
+            total_cents = (sp.deposit_cents or 0) + (sp.shipping_cents or 0)
+            if r.amount >= total_cents and total_cents > 0:
+                r_type = "full"
+            elif r.amount == (sp.deposit_cents or 0) and (sp.deposit_cents or 0) > 0:
+                r_type = "deposit"
+            elif r.amount == (sp.shipping_cents or 0) and (sp.shipping_cents or 0) > 0:
+                r_type = "shipping"
+            else:
+                r_type = "partial"
+        else:
+            r_type = "unknown"
+
+        # Refund type filter (post-query since type is computed)
+        if refund_type and r_type != refund_type:
+            continue
+
+        # Get disputes for this payment
+        if payment:
+            payment_disputes = db.query(Dispute).filter(Dispute.payment_id == payment.payment_id).all()
+            disputes = [
+                {
+                    "dispute_id": d.dispute_id,
+                    "reason": d.reason,
+                    "status": d.status,
+                    "created_at": d.created_at.isoformat() if d.created_at else None,
+                }
+                for d in payment_disputes
+            ]
+
+        # Determine trigger condition from audit logs
+        trigger = "unknown"
+        if sp and order:
+            log = db.query(AuditLog).filter(
+                AuditLog.reference_id == order.id,
+                AuditLog.event_type.in_(["refund_on_cancel", "auto_refund", "refund_payment", "manual_refund"])
+            ).first()
+            if log:
+                if "cancel" in log.event_type:
+                    trigger = "user_cancel"
+                elif "auto" in log.event_type:
+                    trigger = "timeout"
+                elif "manual" in log.event_type:
+                    trigger = "admin_manual"
+                else:
+                    trigger = "payment_flow"
+
+        result.append({
+            "refund_id": r.refund_id,
+            "payment_id": r.payment_id,
+            "amount": r.amount,
+            "currency": r.currency,
+            "status": r.status,
+            "reason": r.reason,
+            "refund_type": r_type,
+            "trigger": trigger,
+            "created_at": r.created_at.isoformat() if r.created_at else None,
+            "updated_at": r.updated_at.isoformat() if r.updated_at else None,
+            "order": {
+                "order_id": order.id if order else None,
+                "status": order.status if order else None,
+                "book_titles": book_titles,
+            } if order else None,
+            "borrower": {
+                "user_id": borrower.user_id,
+                "name": borrower.name,
+                "email": borrower.email,
+            } if borrower else None,
+            "lender": {
+                "user_id": lender.user_id,
+                "name": lender.name,
+                "email": lender.email,
+            } if lender else None,
+            "disputes": disputes,
+        })
+
+    return {
+        "kpi": {
+            "total_count": total_count,
+            "total_amount": total_amount,
+            "succeeded_count": succeeded_count,
+            "failed_count": failed_count,
+            "pending_count": pending_count,
+            "success_rate": success_rate,
+        },
+        "pagination": {
+            "page": page,
+            "page_size": page_size,
+            "total": total_filtered,
+            "total_pages": (total_filtered + page_size - 1) // page_size,
+        },
+        "refunds": result,
+    }
+
+
+@router.get("/refunds/admin/{refund_id}", status_code=status.HTTP_200_OK)
+def get_admin_refund_detail(
+    refund_id: str,
+    admin: "User" = Depends(get_current_admin),
+    db: Session = Depends(get_db),
+):
+    """
+    Admin-only: Get detailed info for a single refund, including Stripe IDs,
+    borrower/lender info, audit timeline, disputes, and payment breakdown.
+    """
+    from models.order import Order, OrderBook
+    from models.payment_split import PaymentSplit
+    from models.payment_gateway import Refund, Payment, AuditLog, Dispute
+    from models.book import Book
+    from models.user import User
+
+    refund = db.query(Refund).filter(Refund.refund_id == refund_id).first()
+    if not refund:
+        raise HTTPException(status_code=404, detail="Refund not found")
+
+    payment = db.query(Payment).filter(Payment.payment_id == refund.payment_id).first()
+    sp = db.query(PaymentSplit).filter(PaymentSplit.payment_id == refund.payment_id).first()
+
+    order = None
+    borrower = None
+    lender = None
+    book_titles = []
+    timeline = []
+    disputes = []
+
+    if sp:
+        order = db.query(Order).filter(Order.id == sp.order_id).first()
+        if order:
+            borrower = db.query(User).filter(User.user_id == order.borrower_id).first()
+            lender = db.query(User).filter(User.user_id == order.owner_id).first()
+            order_books = db.query(OrderBook).filter(OrderBook.order_id == order.id).all()
+            for ob in order_books:
+                book = db.query(Book).filter(Book.id == ob.book_id).first()
+                if book:
+                    book_titles.append(book.title_en or book.title_or or "Unknown")
+
+            # Audit log timeline
+            logs = db.query(AuditLog).filter(
+                AuditLog.reference_id == order.id
+            ).order_by(AuditLog.created_at.asc()).all()
+            timeline = [
+                {
+                    "event": log.event_type,
+                    "actor": log.actor,
+                    "message": log.message,
+                    "timestamp": log.created_at.isoformat() if log.created_at else None,
+                }
+                for log in logs
+            ]
+
+    # Disputes
+    if payment:
+        payment_disputes = db.query(Dispute).filter(Dispute.payment_id == payment.payment_id).all()
+        disputes = [
+            {
+                "dispute_id": d.dispute_id,
+                "user_id": d.user_id,
+                "reason": d.reason,
+                "note": d.note,
+                "status": d.status,
+                "deduction": d.deduction,
+                "created_at": d.created_at.isoformat() if d.created_at else None,
+            }
+            for d in payment_disputes
+        ]
+
+    # Refund type
+    if sp:
+        total_cents = (sp.deposit_cents or 0) + (sp.shipping_cents or 0)
+        if refund.amount >= total_cents and total_cents > 0:
+            r_type = "full"
+        elif refund.amount == (sp.deposit_cents or 0) and (sp.deposit_cents or 0) > 0:
+            r_type = "deposit"
+        elif refund.amount == (sp.shipping_cents or 0) and (sp.shipping_cents or 0) > 0:
+            r_type = "shipping"
+        else:
+            r_type = "partial"
+    else:
+        r_type = "unknown"
+
+    # Trigger condition
+    trigger = "unknown"
+    if sp and order:
+        log = db.query(AuditLog).filter(
+            AuditLog.reference_id == order.id,
+            AuditLog.event_type.in_(["refund_on_cancel", "auto_refund", "refund_payment", "manual_refund"])
+        ).first()
+        if log:
+            if "cancel" in log.event_type:
+                trigger = "user_cancel"
+            elif "auto" in log.event_type:
+                trigger = "timeout"
+            elif "manual" in log.event_type:
+                trigger = "admin_manual"
+            else:
+                trigger = "payment_flow"
+
+    return {
+        "refund_id": refund.refund_id,
+        "payment_id": refund.payment_id,
+        "amount": refund.amount,
+        "currency": refund.currency,
+        "status": refund.status,
+        "reason": refund.reason,
+        "refund_type": r_type,
+        "trigger": trigger,
+        "created_at": refund.created_at.isoformat() if refund.created_at else None,
+        "updated_at": refund.updated_at.isoformat() if refund.updated_at else None,
+        "payment": {
+            "payment_id": payment.payment_id,
+            "amount": payment.amount,
+            "deposit": payment.deposit,
+            "shipping_fee": payment.shipping_fee,
+            "service_fee": payment.service_fee,
+            "status": payment.status,
+            "action_type": payment.action_type,
+        } if payment else None,
+        "payment_split": {
+            "deposit_cents": sp.deposit_cents,
+            "shipping_cents": sp.shipping_cents,
+            "service_fee_cents": sp.service_fee_cents,
+        } if sp else None,
+        "order": {
+            "order_id": order.id,
+            "status": order.status,
+            "book_titles": book_titles,
+            "created_at": order.created_at.isoformat() if order.created_at else None,
+            "canceled_at": order.canceled_at.isoformat() if order.canceled_at else None,
+        } if order else None,
+        "borrower": {
+            "user_id": borrower.user_id,
+            "name": borrower.name,
+            "email": borrower.email,
+        } if borrower else None,
+        "lender": {
+            "user_id": lender.user_id,
+            "name": lender.name,
+            "email": lender.email,
+        } if lender else None,
+        "timeline": timeline,
+        "disputes": disputes,
+    }
+
+
+@router.post("/refunds/admin/{refund_id}/retry", status_code=status.HTTP_200_OK)
+def retry_failed_refund(
+    refund_id: str,
+    admin: "User" = Depends(get_current_admin),
+    db: Session = Depends(get_db),
+):
+    """
+    Admin-only: Retry a failed Stripe refund.
+    Creates a new Stripe refund for the same payment and amount.
+    """
+    from models.payment_gateway import Refund, Payment, AuditLog
+    from models.payment_split import PaymentSplit
+    from models.order import Order
+
+    refund = db.query(Refund).filter(Refund.refund_id == refund_id).first()
+    if not refund:
+        raise HTTPException(status_code=404, detail="Refund not found")
+    if refund.status != "failed":
+        raise HTTPException(status_code=400, detail=f"Refund status is '{refund.status}', only 'failed' refunds can be retried")
+
+    try:
+        new_refund = stripe.Refund.create(
+            payment_intent=refund.payment_id,
+            amount=refund.amount,
+            reason=refund.reason,
+        )
+    except stripe.error.InvalidRequestError as e:
+        raise HTTPException(status_code=400, detail=f"Stripe error: {str(e)}")
+
+    # Update existing refund record with new Stripe refund
+    refund.refund_id = new_refund.id
+    refund.status = new_refund.status
+    refund.updated_at = None  # trigger auto-update
+
+    # Audit log
+    sp = db.query(PaymentSplit).filter(PaymentSplit.payment_id == refund.payment_id).first()
+    order_id = sp.order_id if sp else refund.payment_id
+    log = AuditLog(
+        event_type="admin_retry_refund",
+        reference_id=order_id,
+        actor=admin.user_id,
+        message=f"Admin retried failed refund. Old: {refund_id}, New: {new_refund.id}, Amount: {refund.amount} cents",
+    )
+    db.add(log)
+    db.commit()
+
+    return {
+        "message": "Refund retry initiated",
+        "old_refund_id": refund_id,
+        "new_refund_id": new_refund.id,
+        "amount": refund.amount,
+        "status": new_refund.status,
+    }
+
+
+@router.post("/refunds/admin/manual", status_code=status.HTTP_201_CREATED)
+def manual_admin_refund(
+    order_id: str = Body(..., description="Order ID to refund"),
+    refund_type: str = Body("full", description="Refund type: full/deposit/shipping"),
+    reason: str = Body("Admin manual refund", description="Reason for refund"),
+    admin: "User" = Depends(get_current_admin),
+    db: Session = Depends(get_db),
+):
+    """
+    Admin-only: Manually issue a refund for any order.
+    Works regardless of order status (admin override).
+    """
+    from models.order import Order
+    from models.payment_split import PaymentSplit
+    from models.payment_gateway import Refund, Payment, AuditLog
+
+    order = db.query(Order).filter(Order.id == order_id).first()
+    if not order:
+        raise HTTPException(status_code=404, detail="Order not found")
+
+    sp = db.query(PaymentSplit).filter(PaymentSplit.order_id == order_id).first()
+    if not sp:
+        raise HTTPException(status_code=404, detail="Payment split not found for this order")
+
+    # Calculate refund amount based on type
+    if refund_type == "shipping":
+        refund_amount = int(sp.shipping_cents or 0)
+    elif refund_type == "deposit":
+        refund_amount = int(sp.deposit_cents or 0)
+    else:  # full
+        refund_amount = int(sp.deposit_cents or 0) + int(sp.shipping_cents or 0)
+
+    if refund_amount <= 0:
+        raise HTTPException(status_code=400, detail=f"No refundable amount for refund_type='{refund_type}'")
+
+    # Check if already fully refunded
+    from sqlalchemy import func as sa_func
+    existing_refunded = (
+        db.query(sa_func.coalesce(sa_func.sum(Refund.amount), 0))
+        .filter(Refund.payment_id == sp.payment_id, Refund.status.in_(["succeeded", "pending"]))
+        .scalar()
+    ) or 0
+    payment = db.query(Payment).filter(Payment.payment_id == sp.payment_id).first()
+    if payment and int(existing_refunded) + refund_amount > int(payment.amount or 0):
+        raise HTTPException(status_code=400, detail="Refund amount would exceed original payment amount")
+
+    try:
+        r = stripe.Refund.create(
+            payment_intent=sp.payment_id,
+            amount=refund_amount,
+            reason=reason,
+        )
+    except stripe.error.InvalidRequestError as e:
+        raise HTTPException(status_code=400, detail=f"Stripe error: {str(e)}")
+
+    # Save refund record
+    db_refund = Refund(
+        refund_id=r.id,
+        payment_id=sp.payment_id,
+        amount=refund_amount,
+        currency=r.currency,
+        status=r.status,
+        reason=reason,
+    )
+    db.add(db_refund)
+
+    # Update payment status
+    from sqlalchemy import func as sa_func
+    total_refunded = int(existing_refunded) + refund_amount
+    if payment:
+        if total_refunded >= int(payment.amount or 0):
+            payment.status = "refunded"
+        else:
+            payment.status = "partially_refunded"
+
+    # Update order refund amount
+    order.total_refunded_amount = (order.total_refunded_amount or 0) + refund_amount / 100.0
+
+    # Audit log
+    log = AuditLog(
+        event_type="manual_refund",
+        reference_id=order_id,
+        actor=admin.user_id,
+        message=f"Admin manual refund: {refund_type}, {refund_amount} cents. Reason: {reason}",
+    )
+    db.add(log)
+
+    # Send notification to borrower
+    try:
+        from services.notification_service import NotificationService
+        amount_display = refund_amount / 100
+        NotificationService.create(
+            db, user_id=order.borrower_id, order_id=order.id,
+            type="REFUND",
+            title="Refund Issued",
+            message=f"A refund of ${amount_display:.2f} {r.currency.upper()} has been issued by admin. Reason: {reason}",
+            commit=False,
+        )
+    except Exception as e:
+        print(f"[WARN] Failed to create manual refund notification: {e}")
+
+    db.commit()
+
+    return {
+        "message": "Manual refund issued successfully",
+        "refund_id": r.id,
+        "order_id": order_id,
+        "amount": refund_amount,
+        "currency": r.currency,
+        "status": r.status,
+        "refund_type": refund_type,
+        "reason": reason,
+    }
 
 
 @router.post("/payment/compensate/{payment_id}", status_code=status.HTTP_200_OK)

--- a/frontendNext/app/admin/refunds/[id]/page.tsx
+++ b/frontendNext/app/admin/refunds/[id]/page.tsx
@@ -1,0 +1,397 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+import Link from "next/link";
+import {
+  ArrowLeft,
+  RefreshCw,
+  DollarSign,
+  User,
+  Clock,
+  AlertTriangle,
+  FileText,
+  ShieldAlert,
+} from "lucide-react";
+import { getCurrentUser } from "@/utils/auth";
+import { getAdminRefundDetail, retryRefund } from "@/utils/payments";
+
+const STATUS_META: Record<string, { label: string; className: string; icon: string }> = {
+  succeeded: { label: "Completed", className: "bg-green-100 text-green-700 border-green-200", icon: "check" },
+  pending: { label: "Processing", className: "bg-yellow-100 text-yellow-700 border-yellow-200", icon: "clock" },
+  failed: { label: "Failed", className: "bg-red-100 text-red-700 border-red-200", icon: "alert" },
+};
+
+const TYPE_LABELS: Record<string, string> = {
+  full: "Full Refund",
+  deposit: "Deposit Only",
+  shipping: "Shipping Only",
+  partial: "Partial Refund",
+  unknown: "Unknown",
+};
+
+const TRIGGER_LABELS: Record<string, string> = {
+  user_cancel: "User Cancel",
+  timeout: "Auto Timeout",
+  admin_manual: "Admin Manual",
+  payment_flow: "Payment Flow",
+  unknown: "Unknown",
+};
+
+function isAdminLikeUser(user: { email?: string; is_admin?: boolean } | null) {
+  if (!user) return false;
+  return Boolean(user.is_admin) || Boolean(user.email?.toLowerCase().includes("admin"));
+}
+
+export default function AdminRefundDetailPage() {
+  const params = useParams();
+  const router = useRouter();
+  const refundId = params.id as string;
+
+  const [loading, setLoading] = useState(true);
+  const [meAdmin, setMeAdmin] = useState(false);
+  const [detail, setDetail] = useState<any>(null);
+  const [retrying, setRetrying] = useState(false);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const me = await getCurrentUser();
+        const isAdmin = isAdminLikeUser(me);
+        setMeAdmin(isAdmin);
+        if (isAdmin) {
+          const data = await getAdminRefundDetail(refundId);
+          setDetail(data);
+        }
+      } catch (err) {
+        console.error("[AdminRefundDetail] Failed to load:", err);
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, [refundId]);
+
+  const handleRetry = async () => {
+    if (!confirm("Are you sure you want to retry this failed refund?")) return;
+    try {
+      setRetrying(true);
+      const result = await retryRefund(refundId);
+      alert(`Refund retry initiated! New status: ${result.status}`);
+      // Reload detail
+      const data = await getAdminRefundDetail(result.new_refund_id);
+      setDetail(data);
+      // Update URL to new refund ID
+      router.replace(`/admin/refunds/${result.new_refund_id}`);
+    } catch (err: any) {
+      const msg = err?.response?.data?.detail || err.message || "Unknown error";
+      alert(`Retry failed: ${msg}`);
+    } finally {
+      setRetrying(false);
+    }
+  };
+
+  const fmtAmount = (cents: number, currency?: string) => {
+    const dollars = (cents / 100).toFixed(2);
+    const sym = currency?.toUpperCase() === "AUD" ? "A$" : "$";
+    return `${sym}${dollars}`;
+  };
+
+  const fmtDate = (v?: string | null) => {
+    if (!v) return "-";
+    try {
+      return new Date(v).toLocaleString();
+    } catch {
+      return "-";
+    }
+  };
+
+  if (loading) {
+    return <div className="p-6">Loading refund details...</div>;
+  }
+
+  if (!meAdmin) {
+    return (
+      <div className="max-w-4xl mx-auto p-6">
+        <h1 className="text-2xl font-bold mb-2">Admin Refund Detail</h1>
+        <p className="text-red-600">Admin access required.</p>
+      </div>
+    );
+  }
+
+  if (!detail) {
+    return (
+      <div className="max-w-4xl mx-auto p-6">
+        <h1 className="text-2xl font-bold mb-2">Refund Not Found</h1>
+        <Link href="/admin/refunds" className="text-blue-600 underline">Back to Refund List</Link>
+      </div>
+    );
+  }
+
+  const meta = STATUS_META[detail.status] || STATUS_META["pending"];
+
+  return (
+    <div className="max-w-5xl mx-auto p-6 space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <button
+            onClick={() => router.push("/admin/refunds")}
+            className="flex items-center gap-1 text-gray-500 hover:text-black mb-2 text-sm"
+          >
+            <ArrowLeft className="w-4 h-4" /> Back to Refund List
+          </button>
+          <h1 className="text-2xl font-bold">Refund Detail</h1>
+        </div>
+        {detail.status === "failed" && (
+          <button
+            onClick={handleRetry}
+            disabled={retrying}
+            className="px-4 py-2 bg-red-600 text-white rounded-lg text-sm flex items-center gap-2 hover:bg-red-700 disabled:opacity-60"
+          >
+            <RefreshCw className={`w-4 h-4 ${retrying ? "animate-spin" : ""}`} />
+            {retrying ? "Retrying..." : "Retry Refund"}
+          </button>
+        )}
+      </div>
+
+      {/* Status Banner */}
+      <div className={`rounded-xl border p-4 ${meta.className}`}>
+        <div className="flex items-center justify-between">
+          <div>
+            <span className="text-lg font-bold">{meta.label}</span>
+            <span className="ml-3 text-sm opacity-80">{TYPE_LABELS[detail.refund_type] || detail.refund_type}</span>
+          </div>
+          <div className="text-3xl font-bold">{fmtAmount(detail.amount, detail.currency)}</div>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        {/* Stripe IDs */}
+        <div className="rounded-xl border bg-white p-4 space-y-3">
+          <h2 className="font-semibold flex items-center gap-2">
+            <DollarSign className="w-4 h-4" /> Stripe Information
+          </h2>
+          <div className="space-y-2 text-sm">
+            <div className="flex justify-between">
+              <span className="text-gray-500">Refund ID</span>
+              <span className="font-mono text-xs">{detail.refund_id}</span>
+            </div>
+            <div className="flex justify-between">
+              <span className="text-gray-500">Payment Intent ID</span>
+              <span className="font-mono text-xs">{detail.payment_id}</span>
+            </div>
+            <div className="flex justify-between">
+              <span className="text-gray-500">Currency</span>
+              <span>{detail.currency?.toUpperCase()}</span>
+            </div>
+            <div className="flex justify-between">
+              <span className="text-gray-500">Reason</span>
+              <span>{detail.reason || "N/A"}</span>
+            </div>
+            <div className="flex justify-between">
+              <span className="text-gray-500">Trigger</span>
+              <span>{TRIGGER_LABELS[detail.trigger] || detail.trigger}</span>
+            </div>
+            <div className="flex justify-between">
+              <span className="text-gray-500">Created</span>
+              <span>{fmtDate(detail.created_at)}</span>
+            </div>
+            <div className="flex justify-between">
+              <span className="text-gray-500">Updated</span>
+              <span>{fmtDate(detail.updated_at)}</span>
+            </div>
+          </div>
+        </div>
+
+        {/* Payment Breakdown */}
+        {detail.payment && (
+          <div className="rounded-xl border bg-white p-4 space-y-3">
+            <h2 className="font-semibold flex items-center gap-2">
+              <FileText className="w-4 h-4" /> Payment Breakdown
+            </h2>
+            <div className="space-y-2 text-sm">
+              <div className="flex justify-between">
+                <span className="text-gray-500">Original Payment</span>
+                <span className="font-semibold">{fmtAmount(detail.payment.amount, detail.currency)}</span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-gray-500">Deposit</span>
+                <span>{fmtAmount(detail.payment.deposit || 0, detail.currency)}</span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-gray-500">Shipping Fee</span>
+                <span>{fmtAmount(detail.payment.shipping_fee || 0, detail.currency)}</span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-gray-500">Service Fee</span>
+                <span>{fmtAmount(detail.payment.service_fee || 0, detail.currency)}</span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-gray-500">Payment Status</span>
+                <span className="font-medium">{detail.payment.status}</span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-gray-500">Action Type</span>
+                <span>{detail.payment.action_type}</span>
+              </div>
+              {detail.payment_split && (
+                <>
+                  <hr />
+                  <div className="flex justify-between">
+                    <span className="text-gray-500">Split: Deposit</span>
+                    <span>{fmtAmount(detail.payment_split.deposit_cents, detail.currency)}</span>
+                  </div>
+                  <div className="flex justify-between">
+                    <span className="text-gray-500">Split: Shipping</span>
+                    <span>{fmtAmount(detail.payment_split.shipping_cents, detail.currency)}</span>
+                  </div>
+                  <div className="flex justify-between">
+                    <span className="text-gray-500">Split: Service Fee</span>
+                    <span>{fmtAmount(detail.payment_split.service_fee_cents, detail.currency)}</span>
+                  </div>
+                </>
+              )}
+            </div>
+          </div>
+        )}
+
+        {/* Borrower */}
+        <div className="rounded-xl border bg-white p-4 space-y-3">
+          <h2 className="font-semibold flex items-center gap-2">
+            <User className="w-4 h-4" /> Borrower
+          </h2>
+          {detail.borrower ? (
+            <div className="space-y-2 text-sm">
+              <div className="flex justify-between">
+                <span className="text-gray-500">Name</span>
+                <span className="font-medium">{detail.borrower.name}</span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-gray-500">Email</span>
+                <span>{detail.borrower.email}</span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-gray-500">User ID</span>
+                <span className="font-mono text-xs">{detail.borrower.user_id}</span>
+              </div>
+            </div>
+          ) : (
+            <p className="text-sm text-gray-400">No borrower information available.</p>
+          )}
+        </div>
+
+        {/* Lender */}
+        <div className="rounded-xl border bg-white p-4 space-y-3">
+          <h2 className="font-semibold flex items-center gap-2">
+            <User className="w-4 h-4" /> Lender
+          </h2>
+          {detail.lender ? (
+            <div className="space-y-2 text-sm">
+              <div className="flex justify-between">
+                <span className="text-gray-500">Name</span>
+                <span className="font-medium">{detail.lender.name}</span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-gray-500">Email</span>
+                <span>{detail.lender.email}</span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-gray-500">User ID</span>
+                <span className="font-mono text-xs">{detail.lender.user_id}</span>
+              </div>
+            </div>
+          ) : (
+            <p className="text-sm text-gray-400">No lender information available.</p>
+          )}
+        </div>
+      </div>
+
+      {/* Order Info */}
+      {detail.order && (
+        <div className="rounded-xl border bg-white p-4 space-y-3">
+          <h2 className="font-semibold flex items-center gap-2">
+            <FileText className="w-4 h-4" /> Related Order
+          </h2>
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-4 text-sm">
+            <div>
+              <span className="text-gray-500 block">Order ID</span>
+              <span className="font-mono text-xs">{detail.order.order_id}</span>
+            </div>
+            <div>
+              <span className="text-gray-500 block">Status</span>
+              <span className="font-medium">{detail.order.status}</span>
+            </div>
+            <div>
+              <span className="text-gray-500 block">Books</span>
+              <span>{detail.order.book_titles?.join(", ") || "N/A"}</span>
+            </div>
+            <div>
+              <span className="text-gray-500 block">Created</span>
+              <span>{fmtDate(detail.order.created_at)}</span>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Disputes */}
+      {detail.disputes && detail.disputes.length > 0 && (
+        <div className="rounded-xl border bg-white p-4 space-y-3">
+          <h2 className="font-semibold flex items-center gap-2">
+            <ShieldAlert className="w-4 h-4" /> Related Disputes ({detail.disputes.length})
+          </h2>
+          <div className="space-y-2">
+            {detail.disputes.map((d: any) => (
+              <div key={d.dispute_id} className="rounded-lg border p-3 text-sm">
+                <div className="flex items-center justify-between mb-1">
+                  <span className="font-mono text-xs text-gray-500">{d.dispute_id}</span>
+                  <span className={`px-2 py-0.5 rounded-full text-xs font-medium ${
+                    d.status === "resolved" ? "bg-green-100 text-green-700"
+                    : d.status === "open" ? "bg-yellow-100 text-yellow-700"
+                    : "bg-gray-100 text-gray-700"
+                  }`}>
+                    {d.status}
+                  </span>
+                </div>
+                <p className="text-gray-700">{d.reason}</p>
+                {d.note && <p className="text-gray-500 text-xs mt-1">Note: {d.note}</p>}
+                {d.deduction > 0 && (
+                  <p className="text-xs text-red-600 mt-1">Deduction: {fmtAmount(d.deduction, detail.currency)}</p>
+                )}
+                <p className="text-xs text-gray-400 mt-1">{fmtDate(d.created_at)}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Audit Timeline */}
+      {detail.timeline && detail.timeline.length > 0 && (
+        <div className="rounded-xl border bg-white p-4 space-y-3">
+          <h2 className="font-semibold flex items-center gap-2">
+            <Clock className="w-4 h-4" /> Audit Timeline
+          </h2>
+          <div className="relative pl-6">
+            {detail.timeline.map((log: any, i: number) => (
+              <div key={i} className="relative pb-4 last:pb-0">
+                {/* Timeline line */}
+                {i < detail.timeline.length - 1 && (
+                  <div className="absolute left-[-16px] top-3 w-px h-full bg-gray-200" />
+                )}
+                {/* Timeline dot */}
+                <div className="absolute left-[-20px] top-1.5 w-2 h-2 rounded-full bg-gray-400" />
+                <div className="text-sm">
+                  <div className="flex items-center gap-2">
+                    <span className="font-medium">{log.event}</span>
+                    <span className="text-xs text-gray-400">by {log.actor || "system"}</span>
+                  </div>
+                  <p className="text-gray-600 text-xs mt-0.5">{log.message}</p>
+                  <p className="text-gray-400 text-xs">{fmtDate(log.timestamp)}</p>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontendNext/app/admin/refunds/page.tsx
+++ b/frontendNext/app/admin/refunds/page.tsx
@@ -1,0 +1,507 @@
+"use client";
+
+import { useEffect, useMemo, useState, useCallback } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import {
+  Search,
+  Filter,
+  RefreshCw,
+  DollarSign,
+  CheckCircle2,
+  XCircle,
+  Clock3,
+  ArrowUpDown,
+  ChevronLeft,
+  ChevronRight,
+  Plus,
+} from "lucide-react";
+import { getCurrentUser } from "@/utils/auth";
+import { getAdminRefunds, manualAdminRefund } from "@/utils/payments";
+
+type RefundStatus = "succeeded" | "pending" | "failed";
+
+const STATUS_META: Record<string, { label: string; className: string }> = {
+  succeeded: { label: "Completed", className: "bg-green-100 text-green-700" },
+  pending: { label: "Processing", className: "bg-yellow-100 text-yellow-700" },
+  failed: { label: "Failed", className: "bg-red-100 text-red-700" },
+};
+
+const TYPE_LABELS: Record<string, string> = {
+  full: "Full Refund",
+  deposit: "Deposit Only",
+  shipping: "Shipping Only",
+  partial: "Partial Refund",
+  unknown: "Unknown",
+};
+
+const TRIGGER_LABELS: Record<string, string> = {
+  user_cancel: "User Cancel",
+  timeout: "Timeout",
+  admin_manual: "Admin Manual",
+  payment_flow: "Payment Flow",
+  unknown: "Unknown",
+};
+
+function isAdminLikeUser(user: { email?: string; is_admin?: boolean } | null) {
+  if (!user) return false;
+  return Boolean(user.is_admin) || Boolean(user.email?.toLowerCase().includes("admin"));
+}
+
+interface AdminRefundItem {
+  refund_id: string;
+  payment_id: string;
+  amount: number;
+  currency: string;
+  status: string;
+  reason: string | null;
+  refund_type: string;
+  trigger: string;
+  created_at: string | null;
+  updated_at: string | null;
+  order: {
+    order_id: string;
+    status: string;
+    book_titles: string[];
+  } | null;
+  borrower: { user_id: string; name: string; email: string } | null;
+  lender: { user_id: string; name: string; email: string } | null;
+  disputes: Array<{
+    dispute_id: string;
+    reason: string;
+    status: string;
+    created_at: string | null;
+  }>;
+}
+
+interface KPI {
+  total_count: number;
+  total_amount: number;
+  succeeded_count: number;
+  failed_count: number;
+  pending_count: number;
+  success_rate: number;
+}
+
+interface Pagination {
+  page: number;
+  page_size: number;
+  total: number;
+  total_pages: number;
+}
+
+export default function AdminRefundsPage() {
+  const [loading, setLoading] = useState(true);
+  const [meAdmin, setMeAdmin] = useState(false);
+  const [refunds, setRefunds] = useState<AdminRefundItem[]>([]);
+  const [kpi, setKpi] = useState<KPI>({
+    total_count: 0, total_amount: 0, succeeded_count: 0,
+    failed_count: 0, pending_count: 0, success_rate: 0,
+  });
+  const [pagination, setPagination] = useState<Pagination>({
+    page: 1, page_size: 20, total: 0, total_pages: 0,
+  });
+
+  // Filters
+  const [statusFilter, setStatusFilter] = useState<string>("");
+  const [typeFilter, setTypeFilter] = useState<string>("");
+  const [search, setSearch] = useState("");
+  const [searchInput, setSearchInput] = useState("");
+  const [sortBy, setSortBy] = useState("created_at");
+  const [sortOrder, setSortOrder] = useState("desc");
+  const [page, setPage] = useState(1);
+
+  // Manual refund modal
+  const [showManualRefund, setShowManualRefund] = useState(false);
+  const [manualOrderId, setManualOrderId] = useState("");
+  const [manualRefundType, setManualRefundType] = useState("full");
+  const [manualReason, setManualReason] = useState("");
+  const [manualSubmitting, setManualSubmitting] = useState(false);
+
+  const router = useRouter();
+
+  const loadRefunds = useCallback(async () => {
+    try {
+      setLoading(true);
+      const data = await getAdminRefunds({
+        status_filter: statusFilter || undefined,
+        refund_type: typeFilter || undefined,
+        search: search || undefined,
+        sort_by: sortBy,
+        sort_order: sortOrder,
+        page,
+        page_size: 20,
+      });
+      setRefunds(data.refunds);
+      setKpi(data.kpi);
+      setPagination(data.pagination);
+    } catch (err) {
+      console.error("[AdminRefunds] Failed to load:", err);
+    } finally {
+      setLoading(false);
+    }
+  }, [statusFilter, typeFilter, search, sortBy, sortOrder, page]);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const me = await getCurrentUser();
+        setMeAdmin(isAdminLikeUser(me));
+      } catch {
+        setMeAdmin(false);
+      }
+    })();
+  }, []);
+
+  useEffect(() => {
+    if (meAdmin) loadRefunds();
+  }, [meAdmin, loadRefunds]);
+
+  const handleSearch = () => {
+    setPage(1);
+    setSearch(searchInput);
+  };
+
+  const toggleSort = (field: string) => {
+    if (sortBy === field) {
+      setSortOrder(sortOrder === "desc" ? "asc" : "desc");
+    } else {
+      setSortBy(field);
+      setSortOrder("desc");
+    }
+    setPage(1);
+  };
+
+  const handleManualRefund = async () => {
+    if (!manualOrderId.trim()) {
+      alert("Please enter an Order ID.");
+      return;
+    }
+    try {
+      setManualSubmitting(true);
+      await manualAdminRefund({
+        order_id: manualOrderId.trim(),
+        refund_type: manualRefundType,
+        reason: manualReason.trim() || "Admin manual refund",
+      });
+      alert("Manual refund issued successfully!");
+      setShowManualRefund(false);
+      setManualOrderId("");
+      setManualReason("");
+      loadRefunds();
+    } catch (err: any) {
+      const detail = err?.response?.data?.detail || err.message || "Unknown error";
+      alert(`Failed to issue refund: ${detail}`);
+    } finally {
+      setManualSubmitting(false);
+    }
+  };
+
+  const fmtAmount = (cents: number, currency: string) => {
+    const dollars = (cents / 100).toFixed(2);
+    const sym = currency?.toUpperCase() === "AUD" ? "A$" : "$";
+    return `${sym}${dollars}`;
+  };
+
+  const fmtDate = (v?: string | null) => {
+    if (!v) return "-";
+    try {
+      return new Date(v).toLocaleString();
+    } catch {
+      return "-";
+    }
+  };
+
+  if (!meAdmin && !loading) {
+    return (
+      <div className="max-w-4xl mx-auto p-6">
+        <h1 className="text-2xl font-bold mb-2">Admin Refunds</h1>
+        <p className="text-red-600">Admin access required.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-7xl mx-auto p-6 space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold">Refund Management</h1>
+          <p className="text-gray-600">Monitor and manage all refunds across the platform.</p>
+        </div>
+        <div className="flex gap-2">
+          <button
+            onClick={() => setShowManualRefund(true)}
+            className="px-4 py-2 bg-blue-600 text-white rounded-lg text-sm flex items-center gap-1 hover:bg-blue-700"
+          >
+            <Plus className="w-4 h-4" /> Manual Refund
+          </button>
+          <Link href="/admin/analytics" className="text-sm underline self-center">
+            Back to Dashboard
+          </Link>
+        </div>
+      </div>
+
+      {/* KPI Cards */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <div className="rounded-xl border bg-white p-4">
+          <div className="flex items-center gap-2 text-gray-500 text-sm mb-1">
+            <DollarSign className="w-4 h-4" /> Total Refunded
+          </div>
+          <div className="text-2xl font-bold">{fmtAmount(kpi.total_amount, "usd")}</div>
+          <div className="text-xs text-gray-400">{kpi.total_count} refunds</div>
+        </div>
+        <div className="rounded-xl border bg-white p-4">
+          <div className="flex items-center gap-2 text-green-600 text-sm mb-1">
+            <CheckCircle2 className="w-4 h-4" /> Succeeded
+          </div>
+          <div className="text-2xl font-bold text-green-700">{kpi.succeeded_count}</div>
+          <div className="text-xs text-gray-400">{kpi.success_rate}% success rate</div>
+        </div>
+        <div className="rounded-xl border bg-white p-4">
+          <div className="flex items-center gap-2 text-yellow-600 text-sm mb-1">
+            <Clock3 className="w-4 h-4" /> Pending
+          </div>
+          <div className="text-2xl font-bold text-yellow-700">{kpi.pending_count}</div>
+        </div>
+        <div className="rounded-xl border bg-white p-4">
+          <div className="flex items-center gap-2 text-red-600 text-sm mb-1">
+            <XCircle className="w-4 h-4" /> Failed
+          </div>
+          <div className="text-2xl font-bold text-red-700">{kpi.failed_count}</div>
+        </div>
+      </div>
+
+      {/* Filters */}
+      <div className="rounded-xl border bg-white p-4 space-y-3">
+        {/* Search */}
+        <div className="flex gap-2">
+          <div className="flex-1 relative">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 w-4 h-4" />
+            <input
+              type="text"
+              placeholder="Search by refund ID, order ID, user name, or email..."
+              value={searchInput}
+              onChange={(e) => setSearchInput(e.target.value)}
+              onKeyDown={(e) => e.key === "Enter" && handleSearch()}
+              className="w-full pl-10 pr-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+            />
+          </div>
+          <button
+            onClick={handleSearch}
+            className="px-4 py-2 bg-black text-white rounded-lg text-sm hover:bg-gray-800"
+          >
+            Search
+          </button>
+        </div>
+
+        {/* Status Filter Tabs */}
+        <div className="flex flex-wrap gap-2">
+          <span className="text-sm text-gray-500 self-center mr-1">
+            <Filter className="w-4 h-4 inline" /> Status:
+          </span>
+          {[
+            { value: "", label: "All" },
+            { value: "succeeded", label: "Completed" },
+            { value: "pending", label: "Processing" },
+            { value: "failed", label: "Failed" },
+          ].map((opt) => (
+            <button
+              key={opt.value}
+              onClick={() => { setStatusFilter(opt.value); setPage(1); }}
+              className={`px-3 py-1.5 rounded-md border text-sm ${
+                statusFilter === opt.value ? "bg-black text-white border-black" : "hover:bg-gray-50"
+              }`}
+            >
+              {opt.label}
+            </button>
+          ))}
+        </div>
+
+        {/* Type Filter */}
+        <div className="flex flex-wrap gap-2">
+          <span className="text-sm text-gray-500 self-center mr-1">Type:</span>
+          {[
+            { value: "", label: "All Types" },
+            { value: "full", label: "Full" },
+            { value: "deposit", label: "Deposit" },
+            { value: "shipping", label: "Shipping" },
+            { value: "partial", label: "Partial" },
+          ].map((opt) => (
+            <button
+              key={opt.value}
+              onClick={() => { setTypeFilter(opt.value); setPage(1); }}
+              className={`px-3 py-1.5 rounded-md border text-sm ${
+                typeFilter === opt.value ? "bg-black text-white border-black" : "hover:bg-gray-50"
+              }`}
+            >
+              {opt.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Table */}
+      <div className="rounded-xl border bg-white overflow-hidden">
+        {loading ? (
+          <div className="p-8 text-center text-gray-500">Loading refunds...</div>
+        ) : refunds.length === 0 ? (
+          <div className="p-8 text-center">
+            <RefreshCw className="w-12 h-12 text-gray-300 mx-auto mb-3" />
+            <p className="text-gray-500">No refunds found.</p>
+          </div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead className="bg-gray-50 border-b">
+                <tr>
+                  <th className="text-left px-4 py-3 font-medium text-gray-600">Book</th>
+                  <th className="text-left px-4 py-3 font-medium text-gray-600">Borrower</th>
+                  <th className="text-left px-4 py-3 font-medium text-gray-600">Lender</th>
+                  <th
+                    className="text-left px-4 py-3 font-medium text-gray-600 cursor-pointer select-none"
+                    onClick={() => toggleSort("amount")}
+                  >
+                    <span className="flex items-center gap-1">
+                      Amount <ArrowUpDown className="w-3 h-3" />
+                    </span>
+                  </th>
+                  <th className="text-left px-4 py-3 font-medium text-gray-600">Status</th>
+                  <th className="text-left px-4 py-3 font-medium text-gray-600">Type</th>
+                  <th className="text-left px-4 py-3 font-medium text-gray-600">Trigger</th>
+                  <th
+                    className="text-left px-4 py-3 font-medium text-gray-600 cursor-pointer select-none"
+                    onClick={() => toggleSort("created_at")}
+                  >
+                    <span className="flex items-center gap-1">
+                      Date <ArrowUpDown className="w-3 h-3" />
+                    </span>
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="divide-y">
+                {refunds.map((r) => {
+                  const meta = STATUS_META[r.status] || STATUS_META["pending"];
+                  const bookTitle = r.order?.book_titles?.join(", ") || "N/A";
+                  return (
+                    <tr
+                      key={r.refund_id}
+                      className="hover:bg-gray-50 cursor-pointer"
+                      onClick={() => router.push(`/admin/refunds/${r.refund_id}`)}
+                    >
+                      <td className="px-4 py-3 max-w-[180px] truncate" title={bookTitle}>
+                        {bookTitle}
+                      </td>
+                      <td className="px-4 py-3">
+                        <div className="truncate max-w-[120px]" title={r.borrower?.name}>
+                          {r.borrower?.name || "-"}
+                        </div>
+                        <div className="text-xs text-gray-400 truncate">{r.borrower?.email || ""}</div>
+                      </td>
+                      <td className="px-4 py-3">
+                        <div className="truncate max-w-[120px]" title={r.lender?.name}>
+                          {r.lender?.name || "-"}
+                        </div>
+                        <div className="text-xs text-gray-400 truncate">{r.lender?.email || ""}</div>
+                      </td>
+                      <td className="px-4 py-3 font-semibold">{fmtAmount(r.amount, r.currency)}</td>
+                      <td className="px-4 py-3">
+                        <span className={`px-2 py-0.5 rounded-full text-xs font-medium ${meta.className}`}>
+                          {meta.label}
+                        </span>
+                      </td>
+                      <td className="px-4 py-3 text-xs">{TYPE_LABELS[r.refund_type] || r.refund_type}</td>
+                      <td className="px-4 py-3 text-xs">{TRIGGER_LABELS[r.trigger] || r.trigger}</td>
+                      <td className="px-4 py-3 text-xs text-gray-500">{fmtDate(r.created_at)}</td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+
+        {/* Pagination */}
+        {pagination.total_pages > 1 && (
+          <div className="flex items-center justify-between px-4 py-3 border-t bg-gray-50">
+            <div className="text-sm text-gray-500">
+              Page {pagination.page} of {pagination.total_pages} ({pagination.total} total)
+            </div>
+            <div className="flex gap-2">
+              <button
+                disabled={page <= 1}
+                onClick={() => setPage(page - 1)}
+                className="px-3 py-1.5 rounded border text-sm disabled:opacity-40 hover:bg-gray-100"
+              >
+                <ChevronLeft className="w-4 h-4" />
+              </button>
+              <button
+                disabled={page >= pagination.total_pages}
+                onClick={() => setPage(page + 1)}
+                className="px-3 py-1.5 rounded border text-sm disabled:opacity-40 hover:bg-gray-100"
+              >
+                <ChevronRight className="w-4 h-4" />
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Manual Refund Modal */}
+      {showManualRefund && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+          <div className="bg-white rounded-xl p-6 w-full max-w-md space-y-4">
+            <h2 className="text-lg font-bold">Issue Manual Refund</h2>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">Order ID</label>
+              <input
+                type="text"
+                value={manualOrderId}
+                onChange={(e) => setManualOrderId(e.target.value)}
+                placeholder="Enter order ID..."
+                className="w-full px-3 py-2 border rounded-lg focus:ring-2 focus:ring-blue-500"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">Refund Type</label>
+              <select
+                value={manualRefundType}
+                onChange={(e) => setManualRefundType(e.target.value)}
+                className="w-full px-3 py-2 border rounded-lg"
+              >
+                <option value="full">Full Refund (Deposit + Shipping)</option>
+                <option value="deposit">Deposit Only</option>
+                <option value="shipping">Shipping Only</option>
+              </select>
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">Reason</label>
+              <textarea
+                value={manualReason}
+                onChange={(e) => setManualReason(e.target.value)}
+                placeholder="Reason for refund..."
+                rows={3}
+                className="w-full px-3 py-2 border rounded-lg focus:ring-2 focus:ring-blue-500"
+              />
+            </div>
+            <div className="flex gap-2 justify-end">
+              <button
+                onClick={() => setShowManualRefund(false)}
+                className="px-4 py-2 border rounded-lg text-sm hover:bg-gray-50"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleManualRefund}
+                disabled={manualSubmitting}
+                className="px-4 py-2 bg-blue-600 text-white rounded-lg text-sm hover:bg-blue-700 disabled:opacity-60"
+              >
+                {manualSubmitting ? "Processing..." : "Issue Refund"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontendNext/utils/payments.ts
+++ b/frontendNext/utils/payments.ts
@@ -241,6 +241,134 @@ export async function getUserRefunds(userId: string) {
   };
 }
 
+// MVP6 Phase 3: Admin Refund APIs
+
+export async function getAdminRefunds(params?: {
+  status_filter?: string;
+  refund_type?: string;
+  search?: string;
+  sort_by?: string;
+  sort_order?: string;
+  page?: number;
+  page_size?: number;
+}) {
+  const searchParams = new URLSearchParams();
+  if (params?.status_filter) searchParams.set("status_filter", params.status_filter);
+  if (params?.refund_type) searchParams.set("refund_type", params.refund_type);
+  if (params?.search) searchParams.set("search", params.search);
+  if (params?.sort_by) searchParams.set("sort_by", params.sort_by);
+  if (params?.sort_order) searchParams.set("sort_order", params.sort_order);
+  if (params?.page) searchParams.set("page", String(params.page));
+  if (params?.page_size) searchParams.set("page_size", String(params.page_size));
+
+  const qs = searchParams.toString();
+  const res = await axios.get(
+    `${API_URL}/api/v1/payment_gateway/refunds/admin${qs ? `?${qs}` : ""}`,
+    {
+      headers: { Authorization: `Bearer ${localStorage.getItem("access_token")}` },
+      withCredentials: true,
+    }
+  );
+  return res.data as {
+    kpi: {
+      total_count: number;
+      total_amount: number;
+      succeeded_count: number;
+      failed_count: number;
+      pending_count: number;
+      success_rate: number;
+    };
+    pagination: {
+      page: number;
+      page_size: number;
+      total: number;
+      total_pages: number;
+    };
+    refunds: Array<{
+      refund_id: string;
+      payment_id: string;
+      amount: number;
+      currency: string;
+      status: string;
+      reason: string | null;
+      refund_type: string;
+      trigger: string;
+      created_at: string | null;
+      updated_at: string | null;
+      order: {
+        order_id: string;
+        status: string;
+        book_titles: string[];
+      } | null;
+      borrower: { user_id: string; name: string; email: string } | null;
+      lender: { user_id: string; name: string; email: string } | null;
+      disputes: Array<{
+        dispute_id: string;
+        reason: string;
+        status: string;
+        created_at: string | null;
+      }>;
+    }>;
+  };
+}
+
+export async function getAdminRefundDetail(refundId: string) {
+  const res = await axios.get(
+    `${API_URL}/api/v1/payment_gateway/refunds/admin/${refundId}`,
+    {
+      headers: { Authorization: `Bearer ${localStorage.getItem("access_token")}` },
+      withCredentials: true,
+    }
+  );
+  return res.data;
+}
+
+export async function retryRefund(refundId: string) {
+  const res = await axios.post(
+    `${API_URL}/api/v1/payment_gateway/refunds/admin/${refundId}/retry`,
+    {},
+    {
+      headers: { Authorization: `Bearer ${localStorage.getItem("access_token")}` },
+      withCredentials: true,
+    }
+  );
+  return res.data as {
+    message: string;
+    old_refund_id: string;
+    new_refund_id: string;
+    amount: number;
+    status: string;
+  };
+}
+
+export async function manualAdminRefund(data: {
+  order_id: string;
+  refund_type: string;
+  reason: string;
+}) {
+  const res = await axios.post(
+    `${API_URL}/api/v1/payment_gateway/refunds/admin/manual`,
+    data,
+    {
+      headers: {
+        Authorization: `Bearer ${localStorage.getItem("access_token")}`,
+        "Content-Type": "application/json",
+      },
+      withCredentials: true,
+    }
+  );
+  return res.data as {
+    message: string;
+    refund_id: string;
+    order_id: string;
+    amount: number;
+    currency: string;
+    status: string;
+    refund_type: string;
+    reason: string;
+  };
+}
+
 // Execute compensation transfer after dispute resolved
 export async function compensatePayment(
   paymentId: string,


### PR DESCRIPTION
## Summary
- **Admin Refund List** (`/admin/refunds`): KPI cards (total refunded, succeeded, pending, failed), table view with search, status/type filters, sorting, pagination, and manual refund modal
- **Admin Refund Detail** (`/admin/refunds/[id]`): Stripe IDs, payment breakdown, borrower/lender info, related disputes, audit timeline, and retry button for failed refunds
- **4 new backend APIs**: `GET /refunds/admin` (list+KPI), `GET /refunds/admin/{id}` (detail), `POST /refunds/admin/{id}/retry` (retry failed), `POST /refunds/admin/manual` (admin manual refund)
- **Admin auth**: All endpoints protected by `get_current_admin` dependency

## Test plan
- [ ] Login as `admin@bookhive.com` / `Admin123!`
- [ ] Visit `http://127.0.0.1/admin/refunds` — verify KPI cards, table data, filters, search, pagination
- [ ] Click a refund row — verify detail page shows Stripe IDs, payment breakdown, borrower/lender, timeline
- [ ] Test Manual Refund button with a valid order ID
- [ ] Verify non-admin users cannot access `/admin/refunds`
- [ ] Sidebar "Refunds" entry pending PR #38 merge (admin layout integration)

<img width="2259" height="1262" alt="屏幕截图 2026-04-14 215011" src="https://github.com/user-attachments/assets/361df40d-36ad-4709-9c47-d6d6437338f8" />
<img width="2132" height="1316" alt="屏幕截图 2026-04-14 215050" src="https://github.com/user-attachments/assets/79ad785c-967b-403a-92d0-dfb1b968ee1c" />
