### PR TITLE
chore(admin): add shared admin layout + sidebar

### DIFF
--- a/frontendNext/app/admin/layout.tsx
+++ b/frontendNext/app/admin/layout.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import {
+  LayoutDashboard,
+  BarChart3,
+  Users,
+  BookOpen,
+  ClipboardList,
+  UserCog,
+  MessageSquareWarning,
+  DollarSign,
+  Wallet,
+} from "lucide-react";
+
+type MenuItem = {
+  label: string;
+  href: string;
+  icon: React.ComponentType<{ className?: string }>;
+};
+
+const menuItems: MenuItem[] = [
+  { label: "Dashboard", href: "/admin", icon: LayoutDashboard },
+  { label: "Analytics", href: "/admin/analytics", icon: BarChart3 },
+  { label: "User Metrics", href: "/admin/user-metrics", icon: Users },
+  { label: "Book Metrics", href: "/admin/book-metrics", icon: BookOpen },
+  { label: "View Orders", href: "/admin/view-orders", icon: ClipboardList },
+  { label: "Users", href: "/admin/users", icon: UserCog },
+  { label: "Complaints", href: "/admin/complaints", icon: MessageSquareWarning },
+  { label: "Refunds", href: "/admin/refunds", icon: DollarSign },
+  { label: "Deposits", href: "/admin/deposits", icon: Wallet },
+];
+
+export default function AdminLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const pathname = usePathname();
+
+  const isActive = (href: string) =>
+    href === "/admin" ? pathname === "/admin" : pathname === href || pathname.startsWith(`${href}/`);
+
+  return (
+    <div className="min-h-screen flex bg-gray-100">
+      <aside className="w-64 bg-white border-r border-gray-200 p-5 shrink-0">
+        <h1 className="text-xl font-bold mb-6 text-gray-900">Admin Dashboard</h1>
+        <nav className="space-y-1">
+          {menuItems.map((item) => {
+            const Icon = item.icon;
+            const active = isActive(item.href);
+            return (
+              <Link
+                key={item.href}
+                href={item.href}
+                className={`flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium transition-colors ${
+                  active
+                    ? "bg-blue-100 text-blue-700"
+                    : "text-gray-700 hover:bg-gray-100"
+                }`}
+              >
+                <Icon className="w-4 h-4" />
+                <span>{item.label}</span>
+              </Link>
+            );
+          })}
+        </nav>
+      </aside>
+      <main className="flex-1 min-w-0">{children}</main>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds `frontendNext/app/admin/layout.tsx` — a Next.js App Router layout that wraps every page under `/admin/*` with a shared sidebar navigation.
- Pre-registers menu entries for all current and in-flight admin routes, so future feature PRs can merge without touching this file.
- Pure UI scaffold: contains no business logic and no auth enforcement — each page keeps its own `is_admin` check.

## Menu items included

| Label         | Route                  | Source              |
|---------------|------------------------|---------------------|
| Dashboard     | `/admin`               | reserved            |
| Analytics     | `/admin/analytics`     | already on `main`   |
| User Metrics  | `/admin/user-metrics`  | PR #38              |
| Book Metrics  | `/admin/book-metrics`  | PR #38              |
| View Orders   | `/admin/view-orders`   | PR #38              |
| Users         | `/admin/users`         | already on `main`   |
| Complaints    | `/admin/complaints`    | already on `main`   |
| Refunds       | `/admin/refunds`       | PR #57              |
| Deposits      | `/admin/deposits`      | MVP7 (upcoming)     |

Links to not-yet-merged routes will 404 until their respective PRs land; this is a cosmetic placeholder, not a functional regression.

## Why this is a separate PR
- Unblocks PR #57 (Admin Refund): after this lands, #57 rebases cleanly and its pages automatically inherit the sidebar with zero code change.
- Unblocks upcoming MVP7 (Deposit Management): new pages render under the shared layout from day one.
- Reduces conflict risk with PR #38: when @chamodhii rebases, her `admin/layout.tsx` conflict resolves to "keep the merged version" since her 3 menu items (User/Book Metrics, View Orders) are already pre-baked here.

## Test plan
- [ ] Run `docker compose -f compose.yaml -f compose.dev.yaml up` and sign in as `admin@bookhive.com`.
- [ ] Visit `/admin/users`, `/admin/complaints`, `/admin/analytics` — sidebar renders on the left, page content fills the main area.
- [ ] Click each sidebar link — active item is highlighted (blue background).
- [ ] Confirm no layout regression on non-admin routes (`/`, `/borrowing`, `/refunds`, etc.).
- [ ] Links to not-yet-implemented routes (`/admin/deposits`, `/admin/refunds`, `/admin/user-metrics`, etc.) 404 — expected until those PRs merge.