### PR TITLE
docs: schema-migration guidance and CLAUDE.md project notes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,3 +164,6 @@ fastapi/media/*/deposit_evidence/
 # Local-only docs/notes
 docs/architecture-diagram.html
 如何测试 测试 账户 普通 管理员Admin.txt
+
+# AI assistant local state (per-user, never committed)
+.claude/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,113 @@
+# CLAUDE.md — Project guidance for AI assistants working in this repo
+
+This file captures non-obvious project conventions and recurring pitfalls so future AI assistants (and teammates) don't re-discover them.
+
+## Stack at a glance
+
+- **Frontend:** Next.js (app router) + TypeScript + Tailwind + Shadcn UI → [frontendNext/](frontendNext/)
+- **Backend:** FastAPI + SQLAlchemy (ORM) + PyMySQL → [fastapi/](fastapi/)
+- **DB:** MySQL 8, reached inside the Docker network as host `db:3306`, exposed on host `:3307`
+- **Gateway:** nginx on `:80` proxies `/` to Next and `/api/v1/*` to FastAPI
+- **Dev stack:** `compose.yaml` + `compose.dev.yaml` (no HTTPS, no block rules)
+
+Payments via Stripe (test keys in `.env`). Email via Brevo (placeholder is fine locally).
+
+## Starting and stopping (local dev, Windows/macOS)
+
+```bash
+# First time / after schema changes: clean slate
+docker compose -f compose.yaml -f compose.dev.yaml down -v
+docker compose -f compose.yaml -f compose.dev.yaml up -d --build
+
+# Daily: no -v needed
+docker compose -f compose.yaml -f compose.dev.yaml up -d
+
+# Stop (keep data)
+docker compose -f compose.yaml -f compose.dev.yaml down
+
+# Stop + wipe data
+docker compose -f compose.yaml -f compose.dev.yaml down -v
+```
+
+Access via **http://localhost/** (nginx), **not** `:3000`. API docs at http://localhost:8000/docs.
+
+## ⚠️ Schema migrations — the single biggest gotcha
+
+**The project does not use Alembic.** Tables are created at startup by `Base.metadata.create_all()` in [fastapi/main.py](fastapi/main.py). That function:
+
+- ✅ Creates tables that don't exist yet
+- ❌ Does **not** add new columns to tables that already exist
+- ❌ Does **not** alter FKs, indexes, or column types
+
+**Implication:** any time a branch adds columns to an existing table, every teammate's local MySQL volume must be wiped once with `down -v` before the backend will start. Otherwise they get:
+
+```
+pymysql.err.OperationalError: (1054, "Unknown column '<something>' in 'field list'")
+ERROR:    Application startup failed. Exiting.
+```
+
+The resulting backend crash cascades into a 502 Bad Gateway from nginx for every API call.
+
+### When `down -v` is required
+
+- After pulling a branch that adds/renames DB columns
+- After that branch merges to `main` and teammates pull main
+- Whenever a teammate reports `Unknown column '…' in 'field list'` or startup failure
+
+### When `down -v` is NOT required
+
+- Daily `git pull` that only touches frontend code or service logic
+- Code-only rebuilds: `docker compose … up -d --build`
+
+### If you really need to keep local data
+
+Write explicit `ALTER TABLE` statements for every new column and FK change, then restart without `-v`. Current PRs that shipped schema changes document their ALTER statements in the PR body (see PR #64 for MVP6-1 reference).
+
+## Test accounts (seeded automatically on a fresh DB)
+
+| Role | Email | Password |
+|---|---|---|
+| Admin | `admin@bookhive.com` | `Admin123!` |
+| Lender | `bob@example.com` | `Password123!` |
+| Borrower | `carol@example.com` | `Password123!` |
+
+Seed data comes from [fastapi/seed.py](fastapi/seed.py). It runs automatically on first boot when `users` + `book` are empty, plus `_seed_deposit_demos()` runs idempotently (even when DB is not empty) to keep one `pending_review` deposit demo present.
+
+To force re-seed inside the container:
+```bash
+docker exec -it fastapi-backend python seed.py --force
+```
+
+## Feature-specific notes
+
+### MVP6 Refund / MVP6-1 Deposit Management (PR #57, #62, #64 — merged)
+
+- `is_admin` is on `/user/me`. Admin pages should check `Boolean(user.is_admin)` from this endpoint. Don't fall back to email matching in new code.
+- Restricted users (`is_restricted=true`) are blocked from **borrow** checkouts only — purchases still go through. See [fastapi/routes/order.py::create_order](fastapi/routes/order.py).
+- Deposit arbitration issues partial Stripe refunds via direct `stripe.Refund.create(amount=…)` in [fastapi/services/deposit_service.py](fastapi/services/deposit_service.py), bypassing `payment_gateway_service.refund_payment()` which only supports full-category refunds.
+- `deposit_audit_log.order_id` is **nullable** with `ON DELETE SET NULL` (user-level actions like restrict/unrestrict have no order). If you encounter an older DB with `NOT NULL` + `CASCADE`, it needs the ALTER documented in PR #64.
+
+## Harmless warnings to ignore
+
+```
+WARN[…] compose.yaml: the attribute `version` is obsolete, it will be ignored
+WARN[…] compose.dev.yaml: the attribute `version` is obsolete
+```
+
+Unrelated to any bug. Clean-up is removing the `version:` line at the top of each compose file — a separate chore, not a blocker.
+
+## Commit / PR conventions
+
+- Commit style: conventional commits (`feat(scope): …`, `fix(scope): …`, `refactor(scope): …`, `docs(scope): …`)
+- **Do not add `Co-Authored-By: Claude …`** or any AI attribution in commits or PR bodies.
+- PRs that touch DB schema must document the migration path in the PR body (either `ALTER TABLE` statements or a `down -v` note) so reviewers don't silently get the 1054 error.
+
+## When stuck, read logs first
+
+```bash
+docker ps                                                    # all four containers Up?
+docker compose -f compose.yaml -f compose.dev.yaml logs backend --tail 80
+docker compose -f compose.yaml -f compose.dev.yaml logs nginx  --tail 20
+```
+
+A 502 from the frontend almost always means `backend` exited. `docker ps` will show it as `Exited` or `Restarting`, and the backend log tail will have the Python traceback.

--- a/README.md
+++ b/README.md
@@ -316,6 +316,35 @@ next-frontend    |  ✓ Ready in ...ms
 docker compose -f compose.yaml -f compose.dev.yaml up
 ```
 
+---
+
+### ⚠️ Schema-change startup (after pulling a branch or merging a PR that adds DB columns)
+
+The project uses `Base.metadata.create_all()` (no Alembic). It creates missing tables but **will not add new columns to existing tables**. So whenever a merged/pulled change introduces new columns, your local MySQL volume must be wiped once — otherwise `backend` crashes at startup with `Unknown column '…' in 'field list'`.
+
+**The first time you pull a change that touches the schema (e.g. after MVP6-1 Deposit Management merges to main):**
+
+```bash
+# 1. Sync main
+git checkout main
+git pull origin main
+
+# 2. Rebuild with a CLEAN database (the -v is required, not optional)
+docker compose -f compose.yaml -f compose.dev.yaml down -v
+docker compose -f compose.yaml -f compose.dev.yaml up -d --build
+
+# 3. Verify backend started (wait ~30s first)
+docker compose -f compose.yaml -f compose.dev.yaml logs backend --tail 20
+```
+
+Healthy log tail:
+```
+fastapi-backend  | INFO:     Uvicorn running on http://0.0.0.0:8000
+fastapi-backend  | INFO:     Application startup complete.
+```
+
+Subsequent daily startups don't need `-v` — only re-run it when a new PR adds more columns.
+
 ### Stop the project
 
 ```powershell
@@ -339,6 +368,7 @@ docker compose -f compose.yaml -f compose.dev.yaml down -v
 | `BREVO_SENDER_EMAIL is not configured` | Verification email sender is missing | Add `BREVO_SENDER_EMAIL` and a verified sender in Brevo |
 | `CORS policy blocked` | `ALLOWED_ORIGINS` missing `http://localhost` | Add `http://localhost` to `ALLOWED_ORIGINS` in `.env` |
 | `localhost:3000 refused` | Port 3000 not exposed to host | Access `http://localhost` (no port number) |
+| `Unknown column '…' in 'field list'` / `Application startup failed` in backend logs | Local MySQL volume predates a merged schema change (e.g. MVP6-1 added columns to `users` / `orders`) | `docker compose -f compose.yaml -f compose.dev.yaml down -v && docker compose -f compose.yaml -f compose.dev.yaml up -d --build` |
 
 **Full reset (when nothing else works):**
 


### PR DESCRIPTION
## Summary

Follow-up to PR #64 (MVP6-1 Deposit Management). Adds documentation that helps teammates recover from the schema-mismatch startup failure they hit after pulling `main` without wiping their MySQL volume.

**Why a separate PR:** the MVP6-1 branch was merged to `main` before this documentation was ready. These changes apply to the whole project going forward (not just MVP6-1), so a dedicated docs PR is cleaner than back-porting into the closed PR #64.

## Changes

- **`README.md`** — new *Schema-change startup* subsection explaining when `-v` is required after a schema-changing merge; new row in the Troubleshooting table for `Unknown column '…' in 'field list'` → `docker compose … down -v && up -d --build`.
- **`CLAUDE.md`** (new, repo root) — captures non-obvious project conventions for future contributors and AI assistants:
  - Stack overview + start/stop commands
  - The `Base.metadata.create_all()` pitfall and when `down -v` is required
  - Test-account table
  - MVP6 / MVP6-1 design decisions worth remembering (`is_admin` on `/user/me`, restricted-user scope, direct Stripe refund, nullable `deposit_audit_log.order_id`)
  - Commit / PR conventions (conventional commits, no AI co-author attribution, schema-migration notes required in PR body)
  - "What to ignore" — the `version is obsolete` warning is harmless
- **`.gitignore`** — add `.claude/` so per-user AI assistant state cannot be accidentally committed if someone creates that directory at the repo root.

## Context

When aydenpan pulled `main` after PR #64 merged, his local MySQL volume still had the pre-MVP6-1 schema. Backend crashed on startup with `pymysql.err.OperationalError: (1054, "Unknown column 'users.damage_strike_count' in 'field list'")` and every frontend request became 502 Bad Gateway. Fix was `docker compose … down -v` followed by a rebuild — now documented in two places so the next person sees the fix without needing to ask.

## Test plan

- [ ] Pull this branch and confirm `README.md` renders the new subsection correctly on GitHub
- [ ] Confirm `CLAUDE.md` appears at repo root and renders as expected
- [ ] Confirm `.gitignore` includes the `.claude/` entry
- [ ] No code changes, so no runtime testing required
