### PR TITLE
Adds an admin order detail view

### DIFF
--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -1,3 +1,4 @@
+version: "3.9"
 services:
   db:             # Local MySQL database for development only;
     image: mysql:8.0
@@ -31,12 +32,6 @@ services:
     command: ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
     volumes:
       - ./fastapi:/app
-    healthcheck:
-      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health', timeout=2)"]
-      interval: 5s
-      timeout: 5s
-      retries: 12
-      start_period: 10s
     depends_on:
       db:
         condition: service_healthy    # Wait for MySQL to be ready before starting backend
@@ -56,17 +51,10 @@ services:
       - ./frontendNext:/app
       - frontend_node_modules:/app/node_modules
       - frontend_next_cache:/app/.next
-    healthcheck:
-      test: ["CMD", "node", "-e", "fetch('http://localhost:3000').then((r) => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))"]
-      interval: 5s
-      timeout: 5s
-      retries: 20
-      start_period: 20s
     expose:
       - "3000"
     depends_on:
-      backend:
-        condition: service_healthy
+      - backend
     networks:
       - mynetwork
 
@@ -79,10 +67,8 @@ services:
       - ./nginx/nginx.dev.conf:/etc/nginx/nginx.conf:ro
       - ./nginx/logs:/var/log/nginx
     depends_on:
-      frontend:
-        condition: service_healthy
-      backend:
-        condition: service_healthy
+      - frontend
+      - backend
     networks:
       - mynetwork
 

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -1,4 +1,3 @@
-version: "3.9"
 services:
   db:             # Local MySQL database for development only;
     image: mysql:8.0
@@ -32,6 +31,12 @@ services:
     command: ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
     volumes:
       - ./fastapi:/app
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health', timeout=2)"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+      start_period: 10s
     depends_on:
       db:
         condition: service_healthy    # Wait for MySQL to be ready before starting backend
@@ -51,10 +56,17 @@ services:
       - ./frontendNext:/app
       - frontend_node_modules:/app/node_modules
       - frontend_next_cache:/app/.next
+    healthcheck:
+      test: ["CMD", "node", "-e", "fetch('http://localhost:3000').then((r) => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+      start_period: 20s
     expose:
       - "3000"
     depends_on:
-      - backend
+      backend:
+        condition: service_healthy
     networks:
       - mynetwork
 
@@ -67,8 +79,10 @@ services:
       - ./nginx/nginx.dev.conf:/etc/nginx/nginx.conf:ro
       - ./nginx/logs:/var/log/nginx
     depends_on:
-      - frontend
-      - backend
+      frontend:
+        condition: service_healthy
+      backend:
+        condition: service_healthy
     networks:
       - mynetwork
 

--- a/fastapi/routes/analytics.py
+++ b/fastapi/routes/analytics.py
@@ -4,12 +4,12 @@ from collections import Counter
 
 from fastapi import APIRouter, Depends, Query, HTTPException
 from sqlalchemy import func, text
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, joinedload
 
 from core.dependencies import get_db, get_current_admin
 from models.user import User
 from models.book import Book
-from models.order import Order
+from models.order import Order, OrderBook
 from models.admin_setting import AdminSetting
 from models.complaint import Complaint
 from models.deposit_audit_log import DepositAuditLog
@@ -679,7 +679,15 @@ def get_admin_order_details(
     db: Session = Depends(get_db),
     admin: User = Depends(get_current_admin),
 ):
-    order = db.query(Order).filter(Order.id == order_id).first()
+    order = (
+        db.query(Order)
+        .options(
+            joinedload(Order.books).joinedload(OrderBook.book),
+            joinedload(Order.borrower),
+        )
+        .filter(Order.id == order_id)
+        .first()
+    )
     if not order:
         raise HTTPException(status_code=404, detail="Order not found")
 
@@ -821,7 +829,11 @@ def get_admin_order_details(
             "borrower": user_summary(order.borrower_id),
             "contact": {
                 "name": order.contact_name,
-                "email": order.borrower.email if order.borrower else None,
+                "email": (
+                    users_by_id[order.borrower_id].email
+                    if order.borrower_id in users_by_id
+                    else None
+                ),
                 "phone": order.phone,
             },
         },

--- a/fastapi/routes/analytics.py
+++ b/fastapi/routes/analytics.py
@@ -1,3 +1,4 @@
+import json
 from datetime import date, datetime, timedelta
 from collections import Counter
 
@@ -10,8 +11,28 @@ from models.user import User
 from models.book import Book
 from models.order import Order
 from models.admin_setting import AdminSetting
+from models.complaint import Complaint
+from models.deposit_audit_log import DepositAuditLog
+from models.deposit_evidence import DepositEvidence
+from models.payment_gateway import Dispute, Payment, Refund
+from models.payment_split import PaymentSplit
+from models.review import Review
 
 router = APIRouter(prefix="/analytics", tags=["Analytics"])
+
+
+def _iso(value):
+    return value.isoformat() if value else None
+
+
+def _json_list(value):
+    if not value:
+        return []
+    try:
+        parsed = json.loads(value)
+        return parsed if isinstance(parsed, list) else []
+    except (TypeError, json.JSONDecodeError):
+        return []
 
 
 @router.get("/summary")
@@ -648,6 +669,303 @@ def get_shipping_metrics(
                 "borrower_name": row["borrower_name"],
             }
             for row in recent_shipments
+        ],
+    }
+
+
+@router.get("/orders/{order_id}/details")
+def get_admin_order_details(
+    order_id: str,
+    db: Session = Depends(get_db),
+    admin: User = Depends(get_current_admin),
+):
+    order = db.query(Order).filter(Order.id == order_id).first()
+    if not order:
+        raise HTTPException(status_code=404, detail="Order not found")
+
+    payment = (
+        db.query(Payment)
+        .filter(Payment.payment_id == order.payment_id)
+        .first()
+        if order.payment_id
+        else None
+    )
+
+    refunds = (
+        db.query(Refund)
+        .filter(Refund.payment_id == order.payment_id)
+        .order_by(Refund.created_at.desc())
+        .all()
+        if order.payment_id
+        else []
+    )
+
+    disputes = (
+        db.query(Dispute)
+        .filter(Dispute.payment_id == order.payment_id)
+        .order_by(Dispute.created_at.desc())
+        .all()
+        if order.payment_id
+        else []
+    )
+
+    payment_splits = (
+        db.query(PaymentSplit)
+        .filter(PaymentSplit.order_id == order.id)
+        .order_by(PaymentSplit.created_at.desc())
+        .all()
+    )
+
+    complaints = (
+        db.query(Complaint)
+        .filter(Complaint.order_id == order.id)
+        .order_by(Complaint.created_at.desc())
+        .all()
+    )
+
+    reviews = (
+        db.query(Review)
+        .filter(Review.order_id == order.id)
+        .order_by(Review.created_at.desc())
+        .all()
+    )
+
+    evidence_items = (
+        db.query(DepositEvidence)
+        .filter(DepositEvidence.order_id == order.id)
+        .order_by(DepositEvidence.submitted_at.desc())
+        .all()
+    )
+
+    audit_logs = (
+        db.query(DepositAuditLog)
+        .filter(DepositAuditLog.order_id == order.id)
+        .order_by(DepositAuditLog.created_at.desc())
+        .all()
+    )
+
+    user_ids = {
+        order.owner_id,
+        order.borrower_id,
+        *[c.complainant_id for c in complaints],
+        *[c.respondent_id for c in complaints if c.respondent_id],
+        *[r.reviewer_id for r in reviews],
+        *[r.reviewee_id for r in reviews],
+        *[e.submitter_id for e in evidence_items],
+        *[a.actor_id for a in audit_logs if a.actor_id],
+        *[split.owner_id for split in payment_splits],
+        *[dispute.user_id for dispute in disputes],
+    }
+    users_by_id = {
+        user.user_id: user
+        for user in db.query(User).filter(User.user_id.in_(user_ids)).all()
+    } if user_ids else {}
+
+    def user_summary(user_id):
+        user = users_by_id.get(user_id)
+        if not user:
+            return {"id": user_id, "name": "-", "email": None}
+        return {
+            "id": user.user_id,
+            "name": user.name,
+            "email": user.email,
+            "phone_number": user.phone_number,
+            "city": user.city,
+            "state": user.state,
+            "country": user.country,
+            "is_restricted": bool(user.is_restricted),
+            "restriction_reason": user.restriction_reason,
+            "damage_strike_count": int(user.damage_strike_count or 0),
+            "damage_severity_score": int(user.damage_severity_score or 0),
+            "stripe_account_id": user.stripe_account_id,
+        }
+
+    books = []
+    for order_book in order.books:
+        book = order_book.book
+        if not book:
+            continue
+        books.append({
+            "id": book.id,
+            "title_or": book.title_or,
+            "title_en": book.title_en,
+            "author": book.author,
+            "category": book.category,
+            "condition": book.condition,
+            "status": book.status,
+            "cover_img_url": book.cover_img_url,
+            "can_rent": bool(book.can_rent),
+            "can_sell": bool(book.can_sell),
+            "sale_price": float(book.sale_price or 0),
+            "deposit": float(book.deposit or 0),
+            "max_lending_days": int(book.max_lending_days or 0),
+            "date_added": _iso(book.date_added),
+        })
+
+    return {
+        "order": {
+            "id": order.id,
+            "status": order.status,
+            "action_type": order.action_type,
+            "created_at": _iso(order.created_at),
+            "updated_at": _iso(order.updated_at),
+            "start_at": _iso(order.start_at),
+            "due_at": _iso(order.due_at),
+            "returned_at": _iso(order.returned_at),
+            "completed_at": _iso(order.completed_at),
+            "canceled_at": _iso(order.canceled_at),
+            "notes": order.notes,
+        },
+        "people": {
+            "owner": user_summary(order.owner_id),
+            "borrower": user_summary(order.borrower_id),
+            "contact": {
+                "name": order.contact_name,
+                "email": order.borrower.email if order.borrower else None,
+                "phone": order.phone,
+            },
+        },
+        "books": books,
+        "shipping": {
+            "method": order.shipping_method,
+            "address": {
+                "street": order.street,
+                "city": order.city,
+                "postcode": order.postcode,
+                "country": order.country,
+            },
+            "outbound": {
+                "carrier": order.shipping_out_carrier,
+                "tracking_number": order.shipping_out_tracking_number,
+                "tracking_url": order.shipping_out_tracking_url,
+            },
+            "return": {
+                "carrier": order.shipping_return_carrier,
+                "tracking_number": order.shipping_return_tracking_number,
+                "tracking_url": order.shipping_return_tracking_url,
+            },
+            "estimated_delivery_time": order.estimated_delivery_time,
+        },
+        "payment": {
+            "payment_id": order.payment_id,
+            "payment_status": payment.status if payment else None,
+            "payment_currency": payment.currency if payment else None,
+            "payment_amount_cents": int(payment.amount or 0) if payment else 0,
+            "payment_created_at": _iso(payment.created_at) if payment else None,
+            "payment_updated_at": _iso(payment.updated_at) if payment else None,
+            "payment_action_type": payment.action_type if payment else None,
+            "deposit_or_sale_amount": float(order.deposit_or_sale_amount or 0),
+            "owner_income_amount": float(order.owner_income_amount or 0),
+            "service_fee_amount": float(order.service_fee_amount or 0),
+            "shipping_out_fee_amount": float(order.shipping_out_fee_amount or 0),
+            "total_paid_amount": float(order.total_paid_amount or 0),
+            "total_refunded_amount": float(order.total_refunded_amount or 0),
+            "late_fee_amount": float(order.late_fee_amount or 0),
+            "damage_fee_amount": float(order.damage_fee_amount or 0),
+        },
+        "deposit": {
+            "status": order.deposit_status,
+            "deducted_cents": int(order.deposit_deducted_cents or 0),
+            "damage_severity_final": order.damage_severity_final,
+        },
+        "payment_splits": [
+            {
+                "id": split.id,
+                "payment_id": split.payment_id,
+                "owner": user_summary(split.owner_id),
+                "connected_account_id": split.connected_account_id,
+                "currency": split.currency,
+                "deposit_cents": int(split.deposit_cents or 0),
+                "shipping_cents": int(split.shipping_cents or 0),
+                "service_fee_cents": int(split.service_fee_cents or 0),
+                "transfer_amount_cents": int(split.transfer_amount_cents or 0),
+                "transfer_id": split.transfer_id,
+                "transfer_status": split.transfer_status,
+                "created_at": _iso(split.created_at),
+                "updated_at": _iso(split.updated_at),
+            }
+            for split in payment_splits
+        ],
+        "refunds": [
+            {
+                "id": refund.id,
+                "refund_id": refund.refund_id,
+                "payment_id": refund.payment_id,
+                "amount_cents": int(refund.amount or 0),
+                "currency": refund.currency,
+                "status": refund.status,
+                "reason": refund.reason,
+                "created_at": _iso(refund.created_at),
+                "updated_at": _iso(refund.updated_at),
+            }
+            for refund in refunds
+        ],
+        "disputes": [
+            {
+                "id": dispute.id,
+                "dispute_id": dispute.dispute_id,
+                "payment_id": dispute.payment_id,
+                "user": user_summary(dispute.user_id),
+                "reason": dispute.reason,
+                "note": dispute.note,
+                "status": dispute.status,
+                "deduction_cents": int(dispute.deduction or 0),
+                "created_at": _iso(dispute.created_at),
+            }
+            for dispute in disputes
+        ],
+        "complaints": [
+            {
+                "id": complaint.id,
+                "type": complaint.type,
+                "subject": complaint.subject,
+                "description": complaint.description,
+                "status": complaint.status,
+                "admin_response": complaint.admin_response,
+                "damage_severity": complaint.damage_severity,
+                "evidence_photos": _json_list(complaint.evidence_photos),
+                "complainant": user_summary(complaint.complainant_id),
+                "respondent": user_summary(complaint.respondent_id) if complaint.respondent_id else None,
+                "created_at": _iso(complaint.created_at),
+                "updated_at": _iso(complaint.updated_at),
+            }
+            for complaint in complaints
+        ],
+        "reviews": [
+            {
+                "id": review.id,
+                "rating": int(review.rating or 0),
+                "comment": review.comment,
+                "reviewer": user_summary(review.reviewer_id),
+                "reviewee": user_summary(review.reviewee_id),
+                "created_at": _iso(review.created_at),
+            }
+            for review in reviews
+        ],
+        "deposit_evidence": [
+            {
+                "id": evidence.id,
+                "submitter": user_summary(evidence.submitter_id),
+                "submitter_role": evidence.submitter_role,
+                "photos": _json_list(evidence.photos),
+                "claimed_severity": evidence.claimed_severity,
+                "note": evidence.note,
+                "submitted_at": _iso(evidence.submitted_at),
+            }
+            for evidence in evidence_items
+        ],
+        "deposit_audit_logs": [
+            {
+                "id": audit.id,
+                "actor": user_summary(audit.actor_id) if audit.actor_id else None,
+                "actor_role": audit.actor_role,
+                "action": audit.action,
+                "amount_cents": int(audit.amount_cents or 0) if audit.amount_cents is not None else None,
+                "final_severity": audit.final_severity,
+                "note": audit.note,
+                "created_at": _iso(audit.created_at),
+            }
+            for audit in audit_logs
         ],
     }
 

--- a/frontendNext/app/admin/orders/[orderId]/page.tsx
+++ b/frontendNext/app/admin/orders/[orderId]/page.tsx
@@ -1,0 +1,459 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { useParams, useRouter } from "next/navigation";
+import {
+  AlertTriangle,
+  BookOpen,
+  CreditCard,
+  FileText,
+  MessageSquareWarning,
+  PackageCheck,
+  ReceiptText,
+  ShieldCheck,
+  Star,
+  Truck,
+  Users,
+} from "lucide-react";
+import { getCurrentUser } from "@/utils/auth";
+import {
+  AdminOrderDetails,
+  AdminOrderUser,
+  getAdminOrderDetails,
+} from "@/utils/analytics";
+
+function isAdminLikeUser(user: { is_admin?: boolean } | null) {
+  return Boolean(user?.is_admin);
+}
+
+function fmtDate(value?: string | null) {
+  return value ? new Date(value).toLocaleString() : "-";
+}
+
+function fmtMoney(value?: number | null) {
+  return `$${Number(value || 0).toFixed(2)}`;
+}
+
+function fmtCents(value: unknown) {
+  return `$${(Number(value || 0) / 100).toFixed(2)}`;
+}
+
+function text(value: unknown) {
+  if (value === null || value === undefined || value === "") return "-";
+  return String(value);
+}
+
+function statusClass(status?: string | null) {
+  switch (status) {
+    case "COMPLETED":
+    case "released":
+    case "succeeded":
+    case "resolved":
+      return "bg-green-100 text-green-700";
+    case "BORROWING":
+    case "pending_review":
+    case "pending":
+    case "PENDING_SHIPMENT":
+      return "bg-yellow-100 text-yellow-700";
+    case "OVERDUE":
+    case "forfeited":
+    case "open":
+      return "bg-red-100 text-red-700";
+    default:
+      return "bg-gray-100 text-gray-700";
+  }
+}
+
+function Section({
+  title,
+  icon: Icon,
+  children,
+}: {
+  title: string;
+  icon: React.ComponentType<{ className?: string }>;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="rounded-xl border bg-white p-5 shadow-sm">
+      <div className="flex items-center gap-2 mb-4">
+        <Icon className="w-4 h-4 text-blue-600" />
+        <h2 className="text-lg font-semibold">{title}</h2>
+      </div>
+      {children}
+    </section>
+  );
+}
+
+function Field({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <div>
+      <div className="text-xs uppercase tracking-wide text-gray-500">{label}</div>
+      <div className="mt-1 text-sm font-medium text-gray-900 break-words">{value}</div>
+    </div>
+  );
+}
+
+function UserCard({ title, user }: { title: string; user: AdminOrderUser }) {
+  return (
+    <div className="rounded-lg border bg-gray-50 p-4">
+      <div className="text-sm font-semibold mb-3">{title}</div>
+      <div className="grid grid-cols-1 gap-3">
+        <Field label="Name" value={user.name || "-"} />
+        <Field label="Email" value={user.email || "-"} />
+        <Field label="Phone" value={user.phone_number || "-"} />
+        <Field
+          label="Location"
+          value={[user.city, user.state, user.country].filter(Boolean).join(", ") || "-"}
+        />
+        <Field
+          label="Risk"
+          value={`${user.damage_strike_count ?? 0} strike(s), severity score ${user.damage_severity_score ?? 0}`}
+        />
+        <Field
+          label="Restricted"
+          value={user.is_restricted ? user.restriction_reason || "Yes" : "No"}
+        />
+      </div>
+    </div>
+  );
+}
+
+function EmptyState({ label }: { label: string }) {
+  return <p className="rounded-lg bg-gray-50 p-4 text-sm text-gray-500">{label}</p>;
+}
+
+export default function AdminOrderDetailsPage() {
+  const router = useRouter();
+  const params = useParams<{ orderId: string }>();
+  const orderId = params.orderId;
+
+  const [detail, setDetail] = useState<AdminOrderDetails | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [meAdmin, setMeAdmin] = useState(false);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const me = await getCurrentUser();
+        const admin = isAdminLikeUser(me);
+        setMeAdmin(admin);
+        if (!admin) return;
+
+        const data = await getAdminOrderDetails(orderId);
+        setDetail(data);
+      } catch (err) {
+        console.error(err);
+        setError("Could not load order details.");
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, [orderId]);
+
+  if (loading) {
+    return <p className="p-6 text-gray-600">Loading order details...</p>;
+  }
+
+  if (!meAdmin) {
+    return (
+      <div className="max-w-4xl mx-auto p-6">
+        <h1 className="text-2xl font-bold mb-2">Order Details</h1>
+        <p className="text-red-600">Admin access required.</p>
+      </div>
+    );
+  }
+
+  if (error || !detail) {
+    return (
+      <div className="max-w-4xl mx-auto p-6">
+        <button onClick={() => router.back()} className="text-sm underline mb-4">
+          Back
+        </button>
+        <p className="text-red-600">{error || "Order details unavailable."}</p>
+      </div>
+    );
+  }
+
+  const order = detail.order;
+
+  return (
+    <div className="max-w-7xl mx-auto p-6 space-y-6">
+      <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+        <div>
+          <button onClick={() => router.back()} className="text-sm underline mb-2">
+            Back
+          </button>
+          <h1 className="text-2xl font-bold">Order Details</h1>
+          <p className="text-gray-600 font-mono text-sm break-all">{order.id}</p>
+        </div>
+        <span
+          className={`inline-flex w-fit rounded-full px-3 py-1 text-xs font-semibold ${statusClass(order.status)}`}
+        >
+          {order.status}
+        </span>
+      </div>
+
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <div className="rounded-xl border bg-white p-4">
+          <div className="flex items-center gap-2 text-blue-600 text-sm mb-1">
+            <ReceiptText className="w-4 h-4" /> Type
+          </div>
+          <div className="text-2xl font-bold capitalize">{order.action_type}</div>
+        </div>
+        <div className="rounded-xl border bg-white p-4">
+          <div className="flex items-center gap-2 text-green-600 text-sm mb-1">
+            <CreditCard className="w-4 h-4" /> Total Paid
+          </div>
+          <div className="text-2xl font-bold">{fmtMoney(detail.payment.total_paid_amount)}</div>
+        </div>
+        <div className="rounded-xl border bg-white p-4">
+          <div className="flex items-center gap-2 text-orange-600 text-sm mb-1">
+            <Truck className="w-4 h-4" /> Shipping
+          </div>
+          <div className="text-2xl font-bold capitalize">{detail.shipping.method || "-"}</div>
+        </div>
+        <div className="rounded-xl border bg-white p-4">
+          <div className="flex items-center gap-2 text-violet-600 text-sm mb-1">
+            <ShieldCheck className="w-4 h-4" /> Deposit
+          </div>
+          <div className="text-2xl font-bold capitalize">{detail.deposit.status}</div>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 xl:grid-cols-2 gap-6">
+        <Section title="Order Summary" icon={ReceiptText}>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <Field label="Status" value={order.status} />
+            <Field label="Action Type" value={order.action_type} />
+            <Field label="Created" value={fmtDate(order.created_at)} />
+            <Field label="Updated" value={fmtDate(order.updated_at)} />
+            <Field label="Started" value={fmtDate(order.start_at)} />
+            <Field label="Due" value={fmtDate(order.due_at)} />
+            <Field label="Returned" value={fmtDate(order.returned_at)} />
+            <Field label="Completed" value={fmtDate(order.completed_at)} />
+            <Field label="Canceled" value={fmtDate(order.canceled_at)} />
+            <Field label="Notes" value={order.notes || "-"} />
+          </div>
+        </Section>
+
+        <Section title="People" icon={Users}>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <UserCard title="Owner" user={detail.people.owner} />
+            <UserCard title="Borrower" user={detail.people.borrower} />
+          </div>
+          <div className="mt-4 grid grid-cols-1 md:grid-cols-3 gap-4">
+            <Field label="Contact Name" value={detail.people.contact.name} />
+            <Field label="Contact Email" value={detail.people.contact.email || "-"} />
+            <Field label="Contact Phone" value={detail.people.contact.phone || "-"} />
+          </div>
+        </Section>
+      </div>
+
+      <Section title="Books" icon={BookOpen}>
+        {detail.books.length ? (
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+            {detail.books.map((book) => (
+              <div key={book.id} className="rounded-lg border bg-gray-50 p-4">
+                <div className="font-semibold">{book.title_or}</div>
+                <div className="text-sm text-gray-600">{book.title_en || "-"}</div>
+                <div className="mt-3 grid grid-cols-2 md:grid-cols-4 gap-3">
+                  <Field label="Author" value={book.author || "-"} />
+                  <Field label="Category" value={book.category || "-"} />
+                  <Field label="Condition" value={book.condition || "-"} />
+                  <Field label="Status" value={book.status || "-"} />
+                  <Field label="Sale Price" value={fmtMoney(book.sale_price)} />
+                  <Field label="Deposit" value={fmtMoney(book.deposit)} />
+                  <Field label="Max Lending" value={`${book.max_lending_days} days`} />
+                  <Field label="Date Added" value={fmtDate(book.date_added)} />
+                </div>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <EmptyState label="No books linked to this order." />
+        )}
+      </Section>
+
+      <div className="grid grid-cols-1 xl:grid-cols-2 gap-6">
+        <Section title="Shipping" icon={Truck}>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <Field label="Method" value={detail.shipping.method || "-"} />
+            <Field
+              label="Estimated Delivery"
+              value={
+                detail.shipping.estimated_delivery_time
+                  ? `${detail.shipping.estimated_delivery_time} days`
+                  : "-"
+              }
+            />
+            <Field label="Street" value={detail.shipping.address.street} />
+            <Field
+              label="City / Postcode"
+              value={`${detail.shipping.address.city}, ${detail.shipping.address.postcode}`}
+            />
+            <Field label="Country" value={detail.shipping.address.country} />
+            <Field label="Outbound Carrier" value={detail.shipping.outbound.carrier || "-"} />
+            <Field label="Outbound Tracking" value={detail.shipping.outbound.tracking_number || "-"} />
+            <Field label="Return Carrier" value={detail.shipping.return.carrier || "-"} />
+            <Field label="Return Tracking" value={detail.shipping.return.tracking_number || "-"} />
+          </div>
+        </Section>
+
+        <Section title="Payment" icon={CreditCard}>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <Field label="Payment ID" value={detail.payment.payment_id || "-"} />
+            <Field label="Payment Status" value={detail.payment.payment_status || "-"} />
+            <Field label="Payment Amount" value={fmtCents(detail.payment.payment_amount_cents)} />
+            <Field label="Payment Created" value={fmtDate(detail.payment.payment_created_at)} />
+            <Field label="Deposit / Sale" value={fmtMoney(detail.payment.deposit_or_sale_amount)} />
+            <Field label="Owner Income" value={fmtMoney(detail.payment.owner_income_amount)} />
+            <Field label="Service Fee" value={fmtMoney(detail.payment.service_fee_amount)} />
+            <Field label="Shipping Fee" value={fmtMoney(detail.payment.shipping_out_fee_amount)} />
+            <Field label="Total Paid" value={fmtMoney(detail.payment.total_paid_amount)} />
+            <Field label="Total Refunded" value={fmtMoney(detail.payment.total_refunded_amount)} />
+            <Field label="Late Fee" value={fmtMoney(detail.payment.late_fee_amount)} />
+            <Field label="Damage Fee" value={fmtMoney(detail.payment.damage_fee_amount)} />
+          </div>
+        </Section>
+      </div>
+
+      <div className="grid grid-cols-1 xl:grid-cols-2 gap-6">
+        <Section title="Deposit & Evidence" icon={ShieldCheck}>
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-4">
+            <Field label="Status" value={detail.deposit.status} />
+            <Field label="Deducted" value={fmtCents(detail.deposit.deducted_cents)} />
+            <Field label="Final Severity" value={detail.deposit.damage_severity_final || "-"} />
+          </div>
+          {detail.deposit_evidence.length ? (
+            <div className="space-y-3">
+              {detail.deposit_evidence.map((item) => (
+                <div key={String(item.id)} className="rounded-lg border bg-gray-50 p-4">
+                  <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+                    <Field label="Role" value={text(item.submitter_role)} />
+                    <Field label="Severity" value={text(item.claimed_severity)} />
+                    <Field label="Submitted" value={fmtDate(item.submitted_at as string | null)} />
+                  </div>
+                  <p className="mt-3 text-sm text-gray-700">{text(item.note)}</p>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <EmptyState label="No deposit evidence recorded." />
+          )}
+        </Section>
+
+        <Section title="Payment Splits" icon={PackageCheck}>
+          {detail.payment_splits.length ? (
+            <div className="space-y-3">
+              {detail.payment_splits.map((split) => (
+                <div key={String(split.id)} className="rounded-lg border bg-gray-50 p-4">
+                  <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+                    <Field label="Transfer Status" value={text(split.transfer_status)} />
+                    <Field label="Transfer ID" value={text(split.transfer_id)} />
+                    <Field label="Owner Transfer" value={fmtCents(split.transfer_amount_cents)} />
+                    <Field label="Service Fee" value={fmtCents(split.service_fee_cents)} />
+                  </div>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <EmptyState label="No payment split records found." />
+          )}
+        </Section>
+      </div>
+
+      <div className="grid grid-cols-1 xl:grid-cols-2 gap-6">
+        <Section title="Refunds & Disputes" icon={AlertTriangle}>
+          <h3 className="text-sm font-semibold mb-2">Refunds</h3>
+          {detail.refunds.length ? (
+            <div className="space-y-2 mb-4">
+              {detail.refunds.map((refund) => (
+                <div key={String(refund.id)} className="rounded-lg border bg-gray-50 p-3">
+                  <Field label="Refund" value={`${text(refund.refund_id)} · ${fmtCents(refund.amount_cents)} · ${text(refund.status)}`} />
+                </div>
+              ))}
+            </div>
+          ) : (
+            <EmptyState label="No refunds found." />
+          )}
+          <h3 className="text-sm font-semibold mt-4 mb-2">Disputes</h3>
+          {detail.disputes.length ? (
+            <div className="space-y-2">
+              {detail.disputes.map((dispute) => (
+                <div key={String(dispute.id)} className="rounded-lg border bg-gray-50 p-3">
+                  <Field label="Dispute" value={`${text(dispute.reason)} · ${text(dispute.status)} · ${fmtCents(dispute.deduction_cents)}`} />
+                </div>
+              ))}
+            </div>
+          ) : (
+            <EmptyState label="No disputes found." />
+          )}
+        </Section>
+
+        <Section title="Complaints" icon={MessageSquareWarning}>
+          {detail.complaints.length ? (
+            <div className="space-y-3">
+              {detail.complaints.map((complaint) => (
+                <div key={String(complaint.id)} className="rounded-lg border bg-gray-50 p-4">
+                  <div className="flex flex-wrap items-center gap-2 mb-2">
+                    <span className="font-semibold">{text(complaint.subject)}</span>
+                    <span className={`rounded-full px-2 py-0.5 text-xs font-semibold ${statusClass(complaint.status as string)}`}>
+                      {text(complaint.status)}
+                    </span>
+                  </div>
+                  <p className="text-sm text-gray-700">{text(complaint.description)}</p>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <EmptyState label="No complaints linked to this order." />
+          )}
+        </Section>
+      </div>
+
+      <div className="grid grid-cols-1 xl:grid-cols-2 gap-6">
+        <Section title="Reviews" icon={Star}>
+          {detail.reviews.length ? (
+            <div className="space-y-3">
+              {detail.reviews.map((review) => (
+                <div key={String(review.id)} className="rounded-lg border bg-gray-50 p-4">
+                  <div className="font-semibold">{text(review.rating)} / 5 stars</div>
+                  <p className="mt-2 text-sm text-gray-700">{text(review.comment)}</p>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <EmptyState label="No reviews linked to this order." />
+          )}
+        </Section>
+
+        <Section title="Deposit Audit History" icon={FileText}>
+          {detail.deposit_audit_logs.length ? (
+            <div className="space-y-3">
+              {detail.deposit_audit_logs.map((audit) => (
+                <div key={String(audit.id)} className="rounded-lg border bg-gray-50 p-4">
+                  <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+                    <Field label="Action" value={text(audit.action)} />
+                    <Field label="Actor Role" value={text(audit.actor_role)} />
+                    <Field label="Amount" value={audit.amount_cents === null ? "-" : fmtCents(audit.amount_cents)} />
+                    <Field label="Created" value={fmtDate(audit.created_at as string | null)} />
+                  </div>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <EmptyState label="No deposit audit entries found." />
+          )}
+        </Section>
+      </div>
+
+      <div className="flex justify-end">
+        <Link href="/admin/view-orders" className="text-sm text-blue-600 underline">
+          Back to all orders
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/frontendNext/app/admin/orders/[orderId]/page.tsx
+++ b/frontendNext/app/admin/orders/[orderId]/page.tsx
@@ -35,11 +35,11 @@ function fmtMoney(value?: number | null) {
   return `$${Number(value || 0).toFixed(2)}`;
 }
 
-function fmtCents(value: unknown) {
+function fmtCents(value?: number | null) {
   return `$${(Number(value || 0) / 100).toFixed(2)}`;
 }
 
-function text(value: unknown) {
+function text(value?: string | number | null) {
   if (value === null || value === undefined || value === "") return "-";
   return String(value);
 }
@@ -333,7 +333,7 @@ export default function AdminOrderDetailsPage() {
                   <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
                     <Field label="Role" value={text(item.submitter_role)} />
                     <Field label="Severity" value={text(item.claimed_severity)} />
-                    <Field label="Submitted" value={fmtDate(item.submitted_at as string | null)} />
+                    <Field label="Submitted" value={fmtDate(item.submitted_at)} />
                   </div>
                   <p className="mt-3 text-sm text-gray-700">{text(item.note)}</p>
                 </div>
@@ -371,7 +371,10 @@ export default function AdminOrderDetailsPage() {
             <div className="space-y-2 mb-4">
               {detail.refunds.map((refund) => (
                 <div key={String(refund.id)} className="rounded-lg border bg-gray-50 p-3">
-                  <Field label="Refund" value={`${text(refund.refund_id)} · ${fmtCents(refund.amount_cents)} · ${text(refund.status)}`} />
+                  <Field
+                    label="Refund"
+                    value={`${refund.refund_id} / ${fmtCents(refund.amount_cents)} / ${refund.status}`}
+                  />
                 </div>
               ))}
             </div>
@@ -383,7 +386,10 @@ export default function AdminOrderDetailsPage() {
             <div className="space-y-2">
               {detail.disputes.map((dispute) => (
                 <div key={String(dispute.id)} className="rounded-lg border bg-gray-50 p-3">
-                  <Field label="Dispute" value={`${text(dispute.reason)} · ${text(dispute.status)} · ${fmtCents(dispute.deduction_cents)}`} />
+                  <Field
+                    label="Dispute"
+                    value={`${dispute.reason} / ${dispute.status} / ${fmtCents(dispute.deduction_cents)}`}
+                  />
                 </div>
               ))}
             </div>
@@ -399,8 +405,8 @@ export default function AdminOrderDetailsPage() {
                 <div key={String(complaint.id)} className="rounded-lg border bg-gray-50 p-4">
                   <div className="flex flex-wrap items-center gap-2 mb-2">
                     <span className="font-semibold">{text(complaint.subject)}</span>
-                    <span className={`rounded-full px-2 py-0.5 text-xs font-semibold ${statusClass(complaint.status as string)}`}>
-                      {text(complaint.status)}
+                    <span className={`rounded-full px-2 py-0.5 text-xs font-semibold ${statusClass(complaint.status)}`}>
+                      {complaint.status}
                     </span>
                   </div>
                   <p className="text-sm text-gray-700">{text(complaint.description)}</p>
@@ -438,7 +444,7 @@ export default function AdminOrderDetailsPage() {
                     <Field label="Action" value={text(audit.action)} />
                     <Field label="Actor Role" value={text(audit.actor_role)} />
                     <Field label="Amount" value={audit.amount_cents === null ? "-" : fmtCents(audit.amount_cents)} />
-                    <Field label="Created" value={fmtDate(audit.created_at as string | null)} />
+                    <Field label="Created" value={fmtDate(audit.created_at)} />
                   </div>
                 </div>
               ))}

--- a/frontendNext/app/admin/shipping-dashboard/page.tsx
+++ b/frontendNext/app/admin/shipping-dashboard/page.tsx
@@ -318,7 +318,14 @@ export default function ShippingDashboardPage() {
             {metrics.recent_shipments.length > 0 ? (
               metrics.recent_shipments.map((order) => (
                 <tr key={order.id} className="border-b hover:bg-gray-50 align-top">
-                  <td className="py-3 px-4 font-mono text-xs">{order.id}</td>
+                  <td className="py-3 px-4 font-mono text-xs">
+                    <Link
+                      href={`/admin/orders/${order.id}`}
+                      className="text-blue-600 underline"
+                    >
+                      {order.id}
+                    </Link>
+                  </td>
                   <td className="py-3 px-4">
                     <span
                       className={`inline-block rounded-full px-3 py-1 text-xs font-semibold ${statusClass(order.status)}`}

--- a/frontendNext/app/admin/view-orders/page.tsx
+++ b/frontendNext/app/admin/view-orders/page.tsx
@@ -168,7 +168,14 @@ export default function ViewOrdersPage() {
                             {orders.length > 0 ? (
                                 orders.map((order) => (
                                     <tr key={order.id} className="border-b hover:bg-gray-50 align-top">
-                                        <td className="py-3 px-4">{order.id}</td>
+                                        <td className="py-3 px-4">
+                                            <Link
+                                                href={`/admin/orders/${order.id}`}
+                                                className="text-blue-600 underline"
+                                            >
+                                                {order.id}
+                                            </Link>
+                                        </td>
                                         <td className="py-3 px-4">
                                             <span
                                                 className={`inline-block rounded-full px-3 py-1 text-xs font-semibold ${getStatusBadgeClass(

--- a/frontendNext/utils/analytics.ts
+++ b/frontendNext/utils/analytics.ts
@@ -81,6 +81,91 @@ export type AdminOrderUser = {
   stripe_account_id?: string | null;
 };
 
+export type AdminOrderPaymentSplit = {
+  id: number;
+  payment_id: string;
+  owner: AdminOrderUser;
+  connected_account_id: string;
+  currency: string;
+  deposit_cents: number;
+  shipping_cents: number;
+  service_fee_cents: number;
+  transfer_amount_cents: number;
+  transfer_id: string | null;
+  transfer_status: string | null;
+  created_at: string | null;
+  updated_at: string | null;
+};
+
+export type AdminOrderRefund = {
+  id: number;
+  refund_id: string;
+  payment_id: string;
+  amount_cents: number;
+  currency: string;
+  status: string;
+  reason: string | null;
+  created_at: string | null;
+  updated_at: string | null;
+};
+
+export type AdminOrderDispute = {
+  id: number;
+  dispute_id: string;
+  payment_id: string;
+  user: AdminOrderUser;
+  reason: string;
+  note: string | null;
+  status: string;
+  deduction_cents: number;
+  created_at: string | null;
+};
+
+export type AdminOrderComplaint = {
+  id: string;
+  type: string;
+  subject: string | null;
+  description: string | null;
+  status: string;
+  admin_response: string | null;
+  damage_severity: string | null;
+  evidence_photos: string[];
+  complainant: AdminOrderUser;
+  respondent: AdminOrderUser | null;
+  created_at: string | null;
+  updated_at: string | null;
+};
+
+export type AdminOrderReview = {
+  id: string;
+  rating: number;
+  comment: string | null;
+  reviewer: AdminOrderUser;
+  reviewee: AdminOrderUser;
+  created_at: string | null;
+};
+
+export type AdminOrderDepositEvidence = {
+  id: string;
+  submitter: AdminOrderUser;
+  submitter_role: string;
+  photos: string[];
+  claimed_severity: string;
+  note: string | null;
+  submitted_at: string | null;
+};
+
+export type AdminOrderDepositAuditLog = {
+  id: string;
+  actor: AdminOrderUser | null;
+  actor_role: string;
+  action: string;
+  amount_cents: number | null;
+  final_severity: string | null;
+  note: string | null;
+  created_at: string | null;
+};
+
 export type AdminOrderDetails = {
   order: {
     id: string;
@@ -162,13 +247,13 @@ export type AdminOrderDetails = {
     deducted_cents: number;
     damage_severity_final: string | null;
   };
-  payment_splits: Array<Record<string, unknown>>;
-  refunds: Array<Record<string, unknown>>;
-  disputes: Array<Record<string, unknown>>;
-  complaints: Array<Record<string, unknown>>;
-  reviews: Array<Record<string, unknown>>;
-  deposit_evidence: Array<Record<string, unknown>>;
-  deposit_audit_logs: Array<Record<string, unknown>>;
+  payment_splits: AdminOrderPaymentSplit[];
+  refunds: AdminOrderRefund[];
+  disputes: AdminOrderDispute[];
+  complaints: AdminOrderComplaint[];
+  reviews: AdminOrderReview[];
+  deposit_evidence: AdminOrderDepositEvidence[];
+  deposit_audit_logs: AdminOrderDepositAuditLog[];
 };
 
 function getAuthHeaders() {

--- a/frontendNext/utils/analytics.ts
+++ b/frontendNext/utils/analytics.ts
@@ -66,6 +66,111 @@ export type ShippingMetricsData = {
   }>;
 };
 
+export type AdminOrderUser = {
+  id: string | null;
+  name: string;
+  email?: string | null;
+  phone_number?: string | null;
+  city?: string | null;
+  state?: string | null;
+  country?: string | null;
+  is_restricted?: boolean;
+  restriction_reason?: string | null;
+  damage_strike_count?: number;
+  damage_severity_score?: number;
+  stripe_account_id?: string | null;
+};
+
+export type AdminOrderDetails = {
+  order: {
+    id: string;
+    status: string;
+    action_type: string;
+    created_at: string | null;
+    updated_at: string | null;
+    start_at: string | null;
+    due_at: string | null;
+    returned_at: string | null;
+    completed_at: string | null;
+    canceled_at: string | null;
+    notes: string | null;
+  };
+  people: {
+    owner: AdminOrderUser;
+    borrower: AdminOrderUser;
+    contact: {
+      name: string;
+      email: string | null;
+      phone: string | null;
+    };
+  };
+  books: Array<{
+    id: string;
+    title_or: string;
+    title_en: string | null;
+    author: string | null;
+    category: string | null;
+    condition: string | null;
+    status: string | null;
+    cover_img_url: string | null;
+    can_rent: boolean;
+    can_sell: boolean;
+    sale_price: number;
+    deposit: number;
+    max_lending_days: number;
+    date_added: string | null;
+  }>;
+  shipping: {
+    method: string | null;
+    address: {
+      street: string;
+      city: string;
+      postcode: string;
+      country: string;
+    };
+    outbound: {
+      carrier: string | null;
+      tracking_number: string | null;
+      tracking_url: string | null;
+    };
+    return: {
+      carrier: string | null;
+      tracking_number: string | null;
+      tracking_url: string | null;
+    };
+    estimated_delivery_time: number | null;
+  };
+  payment: {
+    payment_id: string | null;
+    payment_status: string | null;
+    payment_currency: string | null;
+    payment_amount_cents: number;
+    payment_created_at: string | null;
+    payment_updated_at: string | null;
+    payment_action_type: string | null;
+    deposit_or_sale_amount: number;
+    owner_income_amount: number;
+    service_fee_amount: number;
+    shipping_out_fee_amount: number;
+    total_paid_amount: number;
+    total_refunded_amount: number;
+    late_fee_amount: number;
+    damage_fee_amount: number;
+  };
+  deposit: {
+    status: string;
+    deducted_cents: number;
+    damage_severity_final: string | null;
+  };
+  payment_splits: Array<Record<string, unknown>>;
+  refunds: Array<Record<string, unknown>>;
+  disputes: Array<Record<string, unknown>>;
+  complaints: Array<Record<string, unknown>>;
+  reviews: Array<Record<string, unknown>>;
+  deposit_evidence: Array<Record<string, unknown>>;
+  deposit_audit_logs: Array<Record<string, unknown>>;
+};
+
 function getAuthHeaders() {
   return {
     Authorization: `Bearer ${localStorage.getItem("access_token")}`,
@@ -132,6 +237,20 @@ export async function getShippingMetrics(params?: {
     `${API_URL}/api/v1/analytics/shipping-metrics`,
     {
       params: params || {},
+      headers: getAuthHeaders(),
+      withCredentials: true,
+    }
+  );
+
+  return res.data;
+}
+
+export async function getAdminOrderDetails(orderId: string) {
+  const API_URL = getApiUrl();
+
+  const res = await axios.get<AdminOrderDetails>(
+    `${API_URL}/api/v1/analytics/orders/${orderId}/details`,
+    {
       headers: getAuthHeaders(),
       withCredentials: true,
     }


### PR DESCRIPTION
## Summary

Adds an admin order detail view so admins can click an Order ID and see all related order information at a glance.

## Changes

- Added admin order detail endpoint:
  - `GET /api/v1/analytics/orders/{order_id}/details`
- Added `/admin/orders/[orderId]` detail page.
- Linked Order IDs from:
  - `/admin/view-orders`
  - `/admin/shipping-dashboard`
- Order detail page includes:
  - Order summary and status
  - Owner, borrower, and contact details
  - Linked books
  - Shipping address and tracking details
  - Payment totals and fees
  - Deposit status and evidence
  - Payment split records
  - Refunds and disputes
  - Complaints
  - Reviews
  - Deposit audit history

## Testing

- Verified backend route compiles
<img width="1917" height="897" alt="image" src="https://github.com/user-attachments/assets/96f4da94-f2ee-41e4-8786-06987e17e1f3" />
<img width="1917" height="842" alt="image" src="https://github.com/user-attachments/assets/48c3cd42-79a8-4a6c-9934-357e7455771f" />

