### PR TITLE
brevo api key has been exposed

### DIFF
--- a/#.env.example
+++ b/#.env.example
@@ -9,7 +9,7 @@ ALGORITHM=HS256
 ACCESS_TOKEN_EXPIRE_MINUTES=30
  
 ### Email configuration for Brevo (formerly Sendinblue)
-BREVO_API_KEY=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
+BREVO_API_KEY=YOUR_API_KEY
 BREVO_KEY_TYPE=api-key
 BREVO_SENDER_EMAIL=no-reply@bookborrow.org
 BREVO_SENDER_NAME=BookBorrow


### PR DESCRIPTION
generated a new brevo api key to replace from .env; 
removed the previous real api key from .env.example.