### PR TITLE
Test01 - Add Selenium smoke tests and professionalize README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,7 @@ celerybeat-schedule
 # Environments
 .env
 .venv
+.venv-selenium/
 env/
 venv/
 .pytest_cache

--- a/README.md
+++ b/README.md
@@ -1,152 +1,130 @@
-# BookBorrow – Peer-to-Peer Book Lending Platform
+# BookBorrow - Peer-to-Peer Book Lending Platform
 
-BookBorrow is a **community-driven web platform** that allows users to share books in a secure and trustworthy way.
-Users can register, list books for lending, borrow books from others, and complete transactions with accountability ensured through **deposits, reviews, and platform rules**.
+BookBorrow is a community-driven web platform that enables secure and accountable book sharing and borrowing. Users can register, list books, borrow or purchase books, and complete transactions with platform-supported protection mechanisms such as deposits, reviews, and dispute workflows.
 
 ---
 
-## Features
-Product Requirement Document (PRD) can be found here:
-https://skfusc.axshare.com/?g=4
+## Product Reference
 
+Product Requirement Document (PRD):  
+<https://skfusc.axshare.com/?g=4>
 
-### 👤 User Management
+---
 
-- User registration & login
-- Profile management (bio, location, borrowing history, ratings)
-- User reviews & rating system
-- Blacklist system (users can block each other)
-- Platform-maintained global blacklist
-- Misuse reporting & moderation workflow
+## Core Features
 
-------
+### User Management
+- User registration and authentication
+- Profile management (bio, location, history, ratings)
+- User review and reputation system
+- Personal blacklist and platform-wide moderation controls
+- Misuse reporting and complaint handling workflow
 
-### 📖 Book Listing & Borrowing Workflow
+### Book Listing and Borrowing
+- Book listing creation, update, and removal
+- Borrow request lifecycle (request, payment, shipping, return)
+- Real-time status updates and overdue handling
+- Delivery options: pickup and platform shipping
+- Platform-managed deposit lifecycle:
+  - Deposit collection
+  - Deposit release
+  - Deposit deduction for damage/loss
+- Scheduled automation for order state transitions
 
-- List books for lending (title, author, photos, description, condition)
-- Edit / delete book listings
-- Borrow request workflow (request → pay → shipping → return)
-- Real-time borrowing status updates
-- Automatic overdue handling
-- Dual options: self-pickup or platform shipping
-- Platform-managed deposit mechanism
-  - Platform receives deposit
-  - Platform refunds deposit
-  - Deposit deduction for losses/damages
-- Order status automation (scheduled backend tasks)
+### Purchase and Delivery
+- Direct book purchase from owner to borrower
+- Payment processing with platform fee handling
+- Shipping workflow integration and status tracking
+- Refund processing support
 
-------
-
-### 🛒 Purchase & Delivery
-
-- Users may purchase books directly from the owner
-- Platform handles payment & fee deduction
-- Platform-managed shipping workflow
-- Shipping status tracking
-- Platform-issued refunds
-
-------
-
-### 🧾 Payment & Settlement System
-
-- Deposit management (hold, refund, compensation)
-- Platform fee management (borrowing / purchase fee)
-- Dispute settlement & fee distribution
-- Transparent transaction logs
-- Refund tracking
+### Payment and Settlement
+- Deposit hold, release, and compensation operations
+- Borrowing and purchase service fee management
+- Settlement and financial distribution tracking
+- Audit-friendly transaction logs
 - Optional donation support
 
-------
+### Messaging and Notifications
+- Real-time user messaging linked to orders
+- In-app and email notifications
+- Event alerts for request, shipping, return, and dispute changes
+- Communication history for dispute review
 
-### 💬 Messaging, Notifications & Real-time Features
+### Dispute Management
+- Dispute ticket submission
+- Administrative review and intervention
+- Evidence upload support (images, chat excerpts, records)
+- Partial/full deposit deduction decisions
+- Automated settlement updates and ledger consistency
 
-- Real-time chat between users (linked to each order)
-- System notifications (email + in-app)
-- Status change alerts: request updates, shipping, returns, disputes
-- Dispute communication & mediation logs
+### Platform Administration
+- Service fee configuration
+- Global blacklist management
+- Dispute resolution operations
+- Platform rule governance
+- Payment and transaction audit support
+- Scheduled operational tasks
 
-------
-
-### ⚖️ Dispute Management 
-
-- Dispute ticket creation
-- Customer support involvement (Admin)
-- Evidence upload (photos, chat logs, transaction records)
-- Partial or full deposit deduction (Admin)
-- Automated settlement & platform ledger updates
-
-------
-
-### 🔧 Platform Management (Admin)
-
-- Configure service fee rate
-- Manage global blacklist
-- Handle user disputes
-- Modify platform-level rules
-- Transaction & payment audit trail
-- Automated tasks (overdue updates, settlement updates)
 ---
 
 ## Tech Stack
 
 **Frontend**
-
-* [Next.js](https://nextjs.org/) (React framework)
-* TypeScript
-* TailwindCSS / Shadcn UI
+- [Next.js](https://nextjs.org/)
+- TypeScript
+- Tailwind CSS / Shadcn UI
 
 **Backend**
+- [FastAPI](https://fastapi.tiangolo.com/)
+- SQLModel (ORM)
+- MySQL
 
-* [FastAPI](https://fastapi.tiangolo.com/)
-* SQLModel (ORM)
-* MySQL (Database)
-
-**Other Tools**
-
-* GitHub for version control
-* Axure RP for PRD & prototype design
-* Stripe (payment integration)
+**Supporting Tools**
+- GitHub (version control and collaboration)
+- Axure RP (PRD and prototype)
+- Stripe (payments)
+- Brevo (email notifications)
 
 ---
 
 ## Project Timeline
 
-Key milestones include:
+Key milestones:
+- Project setup completed (requirements, PRD, architecture)
+- Authentication baseline completed
+- Borrowing workflow MVP completed
+- Payment integration completed
+- Stabilization, documentation, and demonstration completed
 
-* ✅ Project Ready – Requirements, PRD, and tech stack finalized
-* 🔄 Core Authentication Ready – Registration & login
-* 📖 Book & Loan Workflow MVP – Borrow-return cycle functional
-* 💳 Payment Gateway Integrated – Deposits & transactions live
-* 🚢 Final Delivery – Stable platform, documentation, and demo
-
-*(see [Gantt Chart](docs/gantt.png) for detailed timeline)*
-
----
-
-## 📂 Repository Structure
-
-```
-Bookhive/
-├── frontendNext/         # Next.js frontend
-├── fastapi/          # FastAPI backend (TBD)
-├── docs/             # Project documentation, PRD, meeting notes, diagrams
-└── README.md         # Project overview
-```
+Detailed timeline: [Gantt Chart](docs/gantt.png)
 
 ---
 
-## 📦 Setup & Installation
+## Repository Structure
 
-### 1. Clone the repository
+```text
+BookBorrow/
+├── frontendNext/   # Next.js frontend
+├── fastapi/        # FastAPI backend
+├── docs/           # Project docs, requirements, notes, diagrams
+└── README.md       # Project overview and runbook
+```
+
+---
+
+## Setup and Installation
+
+### 1) Clone Repository
 
 ```bash
-git clone https://github.com/ChienAnTu/Bookhive.git
-cd Bookhive
+git clone https://github.com/ChienAnTu/BookBorrow.git
+cd BookBorrow
 cp .env.example .env
 ```
-Then update detail in .env file
 
-### 2. Frontend Setup
+Update values in `.env` before running services.
+
+### 2) Frontend (Local Non-Docker Option)
 
 ```bash
 cd frontendNext
@@ -154,11 +132,9 @@ npm install
 npm run dev
 ```
 
-Runs the Next.js frontend on [http://localhost:3000](http://localhost:3000)
+Frontend URL: <http://localhost:3000>
 
-### 3. Backend Setup (FastAPI)
-
-Open a new terminal window, navigate to the frontend directory, and start the frontend:
+### 3) Backend (Local Non-Docker Option)
 
 ```bash
 cd fastapi
@@ -166,181 +142,151 @@ pip install -r requirements.txt
 uvicorn main:app --reload --host 0.0.0.0 --port 8000
 ```
 
-Runs backend API at [http://localhost:8000](http://localhost:8000)
+Backend URL: <http://localhost:8000>
 
 ---
 
-## 📖 Documentation & Resources
-
-* 📑 [Draft Requirements](docs/requirements.md)
-* 🖥️ [Axure Prototype](https://chienantu.github.io/Bookhive/prototype/)
-* 📝 Meeting Notes (in `/docs`)
-
----
-
-## 👥 Team & Roles
-
-* Product Manager – Requirement gathering, PRD, client communications
-* Frontend Developers – Next.js implementation
-* Backend Developers – FastAPI, DB, API integration
-* Documentation & QA – SRS, UML, testing support
-
----
-
-# 📚 Bookhive Deployment Guide
-
-## 🚀 How to Start
+## Deployment Guide
 
 ### Production (VPS)
+
 ```bash
 make up
 ```
-- Deploys using `compose.yaml` + `compose.prod.yaml`
-- Runs with HTTPS (TLS via Certbot) and security block rules enabled
-- Accessible at: `https://bookborrow.org`
 
-### Development (Local)
+- Uses `compose.yaml` with `compose.prod.yaml`
+- HTTPS enabled (TLS via Certbot)
+- Security block rules enabled
+- Public endpoint: `https://bookborrow.org`
+
+### Development (Docker Local)
+
 ```bash
 make up-dev
 ```
-- Deploys using `compose.yaml` + `compose.dev.yaml`
-- No TLS, no block rules (simplified for local testing)
-- Accessible at: `http://localhost`
+
+- Uses `compose.yaml` with `compose.dev.yaml`
+- No TLS and no production block rules
+- Local endpoint: `http://localhost`
 
 ---
 
-## 🖥️ Local Development Setup (Windows / Without `make`)
+## Local Docker Setup (Without `make`)
 
 ### Prerequisites
-- [Docker Desktop](https://www.docker.com/products/docker-desktop/) installed and running
-- Git installed
+- [Docker Desktop](https://www.docker.com/products/docker-desktop/)
+- Git
 
-### Step 1 — Configure `.env`
-
-Copy the example file and fill in the values:
+### Step 1 - Configure `.env`
 
 ```powershell
 cp .env.example .env
 ```
 
-Minimum required values for local development:
+Minimum local configuration:
 
 ```env
-DB_USER=myuser
-DB_PASSWORD=123456
+DB_USER=<database-user>
+DB_PASSWORD=<database-password>
 DB_HOST=db
 DB_PORT=3306
-DB_NAME=BookHive
+DB_NAME=BookBorrow
 
 SECRET_KEY=<any-random-string-32-chars-or-more>
 ALGORITHM=HS256
 ACCESS_TOKEN_EXPIRE_MINUTES=30
 
-# Placeholder values — email/payment won't work locally, but the app will start
-BREVO_API_KEY=xkeysib-local-dev-placeholder-key-not-real
-BREVO_KEY_TYPE=api-key
-BREVO_SENDER_EMAIL=no-reply@example.com
-BREVO_SENDER_NAME=BookHive
-STRIPE_SECRET_KEY=sk_test_local_dev_placeholder_not_real
+# Placeholder values for local startup. Replace with real credentials only in private .env files.
+BREVO_API_KEY=<brevo-api-key>
+BREVO_KEY_TYPE=<brevo-key-type>
+BREVO_SENDER_EMAIL=<verified-sender-email>
+BREVO_SENDER_NAME=<sender-display-name>
+STRIPE_SECRET_KEY=<stripe-secret-key>
 
-# Must include http://localhost to avoid CORS errors
+# Required to avoid CORS issues in local dev
 ALLOWED_ORIGINS=http://localhost:3000,http://127.0.0.1:3000,http://localhost,http://127.0.0.1
 ```
 
-### Step 2 — Start Docker Desktop
+### Step 2 - Start Docker Desktop
 
-Open Docker Desktop and wait until the icon in the system tray is stable (not spinning). This takes ~1–2 minutes.
+Wait until Docker is fully initialized.
 
-### Step 3 — Build and start (first time only)
+### Step 3 - First-Time Build and Run
 
 ```powershell
 docker compose -f compose.yaml -f compose.dev.yaml up --build
 ```
 
-### Step 4 — Wait for startup
+### Step 4 - Verify Startup
 
-Startup is complete when you see both lines:
+Startup is healthy when logs include:
 
-### Step 5 — Seed sample data
-
-In the default local Docker setup, the backend now auto-seeds sample users and books on startup if both the `users` and `book` tables are empty.
-
-That means after:
-
-```powershell
-docker compose -f compose.yaml -f compose.dev.yaml up
+```text
+fastapi-backend  | INFO:     Application startup complete.
+next-frontend    | Ready in ...ms
 ```
 
-you normally do not need a second terminal just to seed data.
+### Step 5 - Seed Data (Optional)
 
-If you want to re-seed manually from inside the backend container:
+In local Docker mode, backend startup auto-seeds sample users/books only when both `users` and `book` tables are empty.
+
+Manual seed inside backend container:
 
 ```powershell
 docker exec -it fastapi-backend python seed.py
 ```
 
-To force a manual re-seed:
+Force reseed:
 
 ```powershell
 docker exec -it fastapi-backend python seed.py --force
 ```
 
-To verify the sample books were inserted, open:
-
+Verification endpoints:
 - `http://localhost:8000/api/v1/books`
 - `http://localhost/books`
 
-Important:
+Important notes:
+- Auto-seeding runs only when both tables are empty.
+- Do not run `python fastapi/seed.py` from host unless host Python dependencies and DB access are configured.
+- Default local Docker uses `DB_HOST=db`; manual seed commands should run in `fastapi-backend`.
 
-- Auto-seeding only happens when both the `users` and `book` tables are empty.
-- Do not run `python fastapi/seed.py` directly from the host unless your local Python environment has the backend dependencies installed and your database host is reachable from the host machine.
-- In the default local Docker setup, `.env` uses `DB_HOST=db`, which works inside the Docker network and is why manual seed commands should be run in `fastapi-backend`.
+### Step 6 - Access Services
 
-```
-fastapi-backend  | INFO:     Application startup complete.
-next-frontend    |  ✓ Ready in ...ms
-```
+- Frontend: `http://localhost`
+- Backend docs: `http://localhost:8000/docs`
 
-### Step 5 — Open in browser
-
-| URL | Purpose |
-|-----|---------|
-| `http://localhost` | Frontend (main entry point) |
-| `http://localhost:8000/docs` | Backend API docs |
-
----
-
-### Daily startup (after first time)
+### Daily Startup
 
 ```powershell
 docker compose -f compose.yaml -f compose.dev.yaml up
 ```
 
-### Stop the project
+### Stop Services
 
 ```powershell
-# Stop but keep database data
+# Stop services and keep DB data
 docker compose -f compose.yaml -f compose.dev.yaml down
 
-# Stop and delete database data (full reset)
+# Stop services and remove DB data
 docker compose -f compose.yaml -f compose.dev.yaml down -v
 ```
 
 ---
 
-### Troubleshooting
+## Troubleshooting
 
-| Error | Cause | Fix |
-|-------|-------|-----|
-| `open //./pipe/dockerDesktopLinuxEngine` | Docker Desktop not running | Start Docker Desktop and wait for it to be ready |
-| `Conflict. The container name already in use` | Stale containers from previous run | Run `docker compose ... down` then retry |
-| `ports are not available: 3306` | Local MySQL occupying port 3306 | Already handled — config uses `3307:3306` |
-| `Missing BREVO_API_KEY` | `.env` not configured | Follow Step 1 above |
-| `BREVO_SENDER_EMAIL is not configured` | Verification email sender is missing | Add `BREVO_SENDER_EMAIL` and a verified sender in Brevo |
-| `CORS policy blocked` | `ALLOWED_ORIGINS` missing `http://localhost` | Add `http://localhost` to `ALLOWED_ORIGINS` in `.env` |
-| `localhost:3000 refused` | Port 3000 not exposed to host | Access `http://localhost` (no port number) |
+| Error | Cause | Resolution |
+|-------|-------|------------|
+| `open //./pipe/dockerDesktopLinuxEngine` | Docker Desktop not running | Start Docker Desktop and wait until ready |
+| `Conflict. The container name already in use` | Stale containers | Run `docker compose ... down`, then retry |
+| `ports are not available: 3306` | Local MySQL conflict | Local mapping is `3307:3306`; free conflicting ports if needed |
+| `Missing BREVO_API_KEY` | `.env` missing required values | Update `.env` with Brevo keys |
+| `BREVO_SENDER_EMAIL is not configured` | Sender not configured | Set `BREVO_SENDER_EMAIL` and configure a verified Brevo sender |
+| `CORS policy blocked` | Missing localhost origins | Add localhost entries to `ALLOWED_ORIGINS` |
+| `localhost:3000 refused` | Host port mismatch | Use `http://localhost` for nginx entrypoint |
 
-**Full reset (when nothing else works):**
+Full reset (last resort):
 
 ```powershell
 docker compose -f compose.yaml -f compose.dev.yaml down -v
@@ -350,76 +296,86 @@ docker compose -f compose.yaml -f compose.dev.yaml up --build
 
 ---
 
-## 🛠 Prerequisites
+## Prerequisites
 
-- **Docker & Docker Compose** (required in all environments)  
-- **make** (for simplified commands)
+- Docker and Docker Compose
+- `make` (optional, for shortcut commands)
 
-### Installing `make`
+### Install `make`
 
 #### macOS
 ```bash
 brew install make
 ```
-(macOS may already include `make`; check with `make --version`.)
 
 #### Windows
-1. Install [Chocolatey](https://chocolatey.org/install)  
-   - Open PowerShell as Administrator  
-   - Run:  
-     ```powershell
-     Set-ExecutionPolicy Bypass -Scope Process -Force; `
-     [System.Net.ServicePointManager]::SecurityProtocol = `
-     [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; `
-     iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
-     ```
-
-2. Install make:  
+1. Install [Chocolatey](https://chocolatey.org/install)
+2. Install `make`:
    ```powershell
    choco install make
    ```
-
-3. Restart the terminal and confirm:  
+3. Restart terminal and verify:
    ```powershell
    make --version
    ```
 
 ---
 
-## 📝 Notes
-- The `.env` file is **not committed** – each environment must create and maintain its own.
-- Certificates (`nginx/letsencrypt/`) and logs are **VPS-only** and must never be pushed to GitHub.
-- Development does not require HTTPS (use `http://localhost`).
-- ⚠️ **PLEASE DO NOT PUSH ANY CODES FROM THE PRODUCTION SERVER**  
-  Production is managed **only via GitHub Actions**.  
-  Manual edits or commits made directly on the VPS will break deployment consistency.
+## Documentation and Resources
+
+- [Draft Requirements](docs/requirements.md)
+- [Axure Prototype](https://chienantu.github.io/BookBorrow/prototype/)
+- Meeting notes in `docs/`
 
 ---
 
-## 🔧 Useful Commands
+## Collaboration and Roles
+
+- Product management: requirements, PRD, and stakeholder communication
+- Frontend engineering: Next.js implementation and UX delivery
+- Backend engineering: API, database, and business logic
+- Documentation and QA: reports, diagrams, and testing
+
+---
+
+## Operational Notes
+
+- `.env` is not committed; each environment maintains its own secure version.
+- TLS certificates (`nginx/letsencrypt/`) and VPS runtime artifacts must not be pushed.
+- Local development does not require HTTPS.
+- Do not push code from production servers. Production changes must flow through GitHub-based workflows to preserve traceability and deployment consistency.
+
+---
+
+## Useful Commands
 
 ### Production
+
 ```bash
-make up        # start containers in production mode
-make down      # stop containers
-make build     # rebuild containers
-make logs      # follow logs (nginx, frontend, backend)
+make up
+make down
+make build
+make logs
 ```
 
 ### Development
+
 ```bash
-make up-dev    # start containers in development mode
-make down-dev  # stop containers
-make build-dev # rebuild containers
-make logs-dev  # follow logs (nginx, frontend, backend)
+make up-dev
+make down-dev
+make build-dev
+make logs-dev
 ```
 
-### Clean-up
+### Cleanup
+
 ```bash
-make clean     # prune unused Docker images, networks, volumes
+make clean
 ```
 
-## 🔒 License
+---
 
-This project is for academic purposes (University Capstone Project).
-All rights reserved to the project contributors. 
+## License
+
+This project is developed for academic capstone purposes.  
+All rights are reserved by the project contributors.

--- a/tests/selenium/README.md
+++ b/tests/selenium/README.md
@@ -1,0 +1,37 @@
+# Selenium Smoke Tests
+
+These tests cover browser-level smoke checks for the BookBorrow frontend and public API routing.
+
+By default, the tests target a local deployment:
+
+```bash
+python3 -m venv .venv-selenium
+source .venv-selenium/bin/activate
+pip install -r tests/selenium/requirements.txt
+BASE_URL=http://localhost python -m unittest discover -s tests/selenium
+```
+
+To run the same read-only smoke checks against the deployed VPS site:
+
+```bash
+BASE_URL=https://www.bookborrow.org python -m unittest discover -s tests/selenium
+```
+
+## Safety
+
+- The tests only load pages and perform GET requests.
+- They do not submit login, registration, checkout, payment, email, or admin forms.
+- Running with `BASE_URL=https://www.bookborrow.org` should not create or modify production data.
+- Guest users hitting protected routes (for example `/checkout`) are redirected to `/auth` by `AuthProvider`; the checkout test accepts either that redirect or an in-page "login required" state if protection rules change.
+
+## Optional Environment Variables
+
+- `BASE_URL`: target site URL. Defaults to `http://localhost`.
+- `SELENIUM_BROWSER`: `chrome`, `edge`, `firefox`, or `safari`. Defaults to `chrome`.
+- `SELENIUM_HEADLESS`: set to `0` to show the browser. Defaults to headless mode.
+
+Safari does not support Selenium headless mode. If using Safari on macOS, enable Remote Automation in Safari's Develop menu and run:
+
+```bash
+SELENIUM_BROWSER=safari SELENIUM_HEADLESS=0 BASE_URL=http://localhost python -m unittest discover -s tests/selenium
+```

--- a/tests/selenium/requirements.txt
+++ b/tests/selenium/requirements.txt
@@ -1,0 +1,1 @@
+selenium

--- a/tests/selenium/test_smoke.py
+++ b/tests/selenium/test_smoke.py
@@ -1,0 +1,189 @@
+import os
+import unittest
+from urllib.parse import urljoin
+
+from selenium import webdriver
+from selenium.common.exceptions import TimeoutException
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+
+
+BASE_URL = os.getenv("BASE_URL", "http://localhost").rstrip("/")
+BROWSER = os.getenv("SELENIUM_BROWSER", "chrome").lower()
+HEADLESS = os.getenv("SELENIUM_HEADLESS", "1") != "0"
+
+
+def build_driver():
+    if BROWSER == "safari":
+        return webdriver.Safari()
+
+    if BROWSER == "firefox":
+        options = webdriver.FirefoxOptions()
+        if HEADLESS:
+            options.add_argument("-headless")
+        return webdriver.Firefox(options=options)
+
+    if BROWSER == "edge":
+        options = webdriver.EdgeOptions()
+        if HEADLESS:
+            options.add_argument("--headless=new")
+        options.add_argument("--window-size=1440,1000")
+        return webdriver.Edge(options=options)
+
+    options = webdriver.ChromeOptions()
+    if HEADLESS:
+        options.add_argument("--headless=new")
+    options.add_argument("--window-size=1440,1000")
+    options.add_argument("--disable-dev-shm-usage")
+    options.add_argument("--no-sandbox")
+    return webdriver.Chrome(options=options)
+
+
+class BookBorrowSmokeTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.driver = build_driver()
+        cls.wait = WebDriverWait(cls.driver, 15)
+        cls.long_wait = WebDriverWait(cls.driver, 25)
+        cls.driver.get(urljoin(f"{BASE_URL}/", ""))
+        cls.wait.until(
+            lambda driver: driver.execute_script("return document.readyState") == "complete"
+        )
+        cls.driver.delete_all_cookies()
+        try:
+            cls.driver.execute_script("window.localStorage.clear(); window.sessionStorage.clear();")
+        except Exception:
+            pass
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.driver.quit()
+
+    def open_path(self, path):
+        self.driver.get(urljoin(f"{BASE_URL}/", path.lstrip("/")))
+        self.wait_for_ready()
+        self.wait_for_app_shell()
+
+    def wait_for_ready(self):
+        self.wait.until(
+            lambda driver: driver.execute_script("return document.readyState") == "complete"
+        )
+
+    def wait_for_app_shell(self, min_chars=40):
+        """Wait until the client shell is past generic full-screen loading placeholders."""
+
+        def meaningful_content(driver):
+            raw = driver.find_element(By.TAG_NAME, "body").text
+            stripped = raw.strip()
+            if len(stripped) < min_chars:
+                return False
+            if "Loading..." in raw:
+                return False
+            return True
+
+        self.long_wait.until(meaningful_content)
+
+    def page_text(self):
+        return self.driver.find_element(By.TAG_NAME, "body").text
+
+    def assert_no_obvious_next_error(self):
+        text = self.page_text()
+        blocked_phrases = [
+            "Application error",
+            "Internal Server Error",
+            "Unhandled Runtime Error",
+            "This page could not be found",
+        ]
+        for phrase in blocked_phrases:
+            self.assertNotIn(phrase, text)
+
+    def fetch_status(self, path):
+        self.driver.get(urljoin(f"{BASE_URL}/", "/"))
+        self.wait_for_ready()
+        self.wait_for_app_shell()
+        script = """
+            const done = arguments[arguments.length - 1];
+            fetch(arguments[0], { method: "GET" })
+                .then((response) => done({ status: response.status, type: response.headers.get("content-type") || "" }))
+                .catch((error) => done({ status: 0, error: String(error) }));
+        """
+        return self.driver.execute_async_script(script, path)
+
+    def test_public_routes_load_successfully(self):
+        expected_routes = [
+            "/",
+            "/login",
+            "/register",
+            "/books",
+            "/checkout",
+            "/message",
+            "/borrowing",
+            "/admin/user-metrics",
+            "/admin/analytics",
+            "/admin/complaints",
+            "/shipping",
+        ]
+
+        for path in expected_routes:
+            with self.subTest(path=path):
+                self.open_path(path)
+                self.assert_no_obvious_next_error()
+                self.assertGreater(len(self.page_text()), 20)
+
+    def test_login_and_register_forms_are_available(self):
+        self.open_path("/login")
+        self.driver.find_element(By.CSS_SELECTOR, "input[type='email']")
+        self.driver.find_element(By.CSS_SELECTOR, "input[type='password']")
+        self.assertIn("Sign In", self.page_text())
+
+        self.open_path("/register")
+        self.driver.find_element(By.CSS_SELECTOR, "input[type='email']")
+        self.driver.find_element(By.CSS_SELECTOR, "input[type='password']")
+        self.assertIn("Create", self.page_text())
+
+    def test_checkout_guest_fallback_is_visible(self):
+        self.open_path("/checkout")
+        url = self.driver.current_url
+        text = self.page_text()
+        if "/auth" in url:
+            self.assertIn("Find Your Next Reading", text)
+            self.assertIn("Login", text)
+        else:
+            self.assertIn("/checkout", url)
+            self.assertTrue(
+                any(
+                    phrase in text
+                    for phrase in [
+                        "Login required",
+                        "Preparing checkout",
+                        "sign in to continue",
+                        "Your checkout is empty",
+                        "Checkout unavailable",
+                    ]
+                ),
+                text,
+            )
+        self.assert_no_obvious_next_error()
+
+    def test_books_api_is_reachable_through_nginx(self):
+        result = self.fetch_status("/api/v1/books?page=1&page_size=5")
+        self.assertEqual(result["status"], 200, result)
+        self.assertIn("application/json", result["type"])
+
+    def test_api_root_reaches_backend(self):
+        result = self.fetch_status("/api/")
+        self.assertEqual(result["status"], 404, result)
+        self.assertIn("application/json", result["type"])
+
+    def test_mobile_message_page_smoke(self):
+        self.driver.set_window_size(390, 844)
+        try:
+            self.open_path("/message")
+        except TimeoutException:
+            self.fail("Message page did not finish loading in mobile viewport")
+        self.assert_no_obvious_next_error()
+        self.assertGreater(len(self.page_text()), 20)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a Selenium smoke test suite under `tests/selenium` for public route, auth form, API reachability, and mobile viewport checks
- document how to run Selenium smoke tests locally and against production in a read-only manner
- rewrite `README.md` in a more professional structure, remove emoji styling, standardize naming to `BookBorrow`, and replace sensitive example values with placeholders

## Test plan
- [x] `BASE_URL=https://www.bookborrow.org python -m unittest discover -s tests/selenium -v`
- [x] `BASE_URL=http://localhost python -m unittest discover -s tests/selenium -v`