### PR TITLE
Refine rental, checkout, shipping, and time handling

### DIFF
--- a/fastapi/models/checkout.py
+++ b/fastapi/models/checkout.py
@@ -73,6 +73,7 @@ class CheckoutItemBase(BaseModel):
     actionType: str
     price: Optional[float] = None
     deposit: Optional[float] = None
+    rentalDays: Optional[int] = None
     shippingMethod: Optional[str] = None
     shippingQuote: Optional[float] = None
     serviceCode: Optional[str] = "AUS_PARCEL_REGULAR"

--- a/fastapi/models/order.py
+++ b/fastapi/models/order.py
@@ -11,6 +11,7 @@ from sqlalchemy import (
 from sqlalchemy.sql import func
 from sqlalchemy.orm import relationship
 from models.base import Base
+from utils.datetime import to_utc_iso
 from typing import Dict
  
 # Order status enum - matches frontend OrderStatus
@@ -128,6 +129,10 @@ class Order(Base):
     owner = relationship("User", foreign_keys=[owner_id])
     borrower = relationship("User", foreign_keys=[borrower_id])
     payment = relationship("Payment", back_populates = "orders")
+
+    @staticmethod
+    def _to_utc_iso(value: datetime | None) -> str | None:
+        return to_utc_iso(value)
  
     def to_dict(self, include_books: bool = True) -> Dict:
         """
@@ -166,9 +171,9 @@ class Order(Base):
             "totalPaidAmount": float(self.total_paid_amount or 0),
             "paymentMethod": "Card via Stripe" if self.payment_id else None,
             "paymentTime": (
-                self.payment.created_at.isoformat()
+                self._to_utc_iso(self.payment.created_at)
                 if self.payment and self.payment.created_at
-                else (self.created_at.isoformat() if self.created_at else None)
+                else self._to_utc_iso(self.created_at)
             ),
             "contactName": self.contact_name,
             "contactEmail": self.borrower.email if self.borrower else None,
@@ -177,16 +182,16 @@ class Order(Base):
             "city": self.city,
             "postcode": self.postcode,
             "country": self.country,
-            "createdAt": self.created_at.isoformat() if self.created_at else None,
-            "updatedAt": self.updated_at.isoformat() if self.updated_at else None,
-            "dueAt": self.due_at.isoformat() if getattr(self, "due_at", None) else None,
+            "createdAt": self._to_utc_iso(self.created_at),
+            "updatedAt": self._to_utc_iso(self.updated_at),
+            "dueAt": self._to_utc_iso(getattr(self, "due_at", None)),
             "books": books_list,
             "paymentId": self.payment_id,
 
-            "startAt": self.start_at.isoformat() if self.start_at else None,
-            "returnedAt": self.returned_at.isoformat() if self.returned_at else None,
-            "completedAt": self.completed_at.isoformat() if self.completed_at else None,
-            "canceledAt": self.canceled_at.isoformat() if self.canceled_at else None,
+            "startAt": self._to_utc_iso(self.start_at),
+            "returnedAt": self._to_utc_iso(self.returned_at),
+            "completedAt": self._to_utc_iso(self.completed_at),
+            "canceledAt": self._to_utc_iso(self.canceled_at),
             
             "shippingOutTrackingNumber": self.shipping_out_tracking_number,
             "shippingOutTrackingUrl": self.shipping_out_tracking_url,

--- a/fastapi/routes/books.py
+++ b/fastapi/routes/books.py
@@ -106,7 +106,7 @@ class BookCreate(BaseModel):
     isbn: Optional[str] = None
     tags: Optional[List[str]] = None
     publishYear: Optional[int] = None
-    maxLendingDays: int = 14
+    maxLendingDays: int = Field(30, ge=1, le=30)
     depositIncomePercentage: int = Field(0, ge=0, le=20)
     deliveryMethod: Literal["post","pickup","both"] = "both"
     salePrice: Optional[float] = None
@@ -128,7 +128,7 @@ class BookUpdate(BaseModel):
     isbn: Optional[str] = None
     tags: Optional[List[str]] = None
     publishYear: Optional[int] = None
-    maxLendingDays: Optional[int] = None
+    maxLendingDays: Optional[int] = Field(None, ge=1, le=30)
     depositIncomePercentage: Optional[int] = Field(None, ge=0, le=20)
     deliveryMethod: Optional[Literal["post","pickup","both"]] = None
     salePrice: Optional[float] = None

--- a/fastapi/routes/checkout.py
+++ b/fastapi/routes/checkout.py
@@ -19,6 +19,7 @@ def _checkout_item_to_dict(item: CheckoutItem) -> dict:
         "actionType": item.action_type,
         "price": float(item.price) if item.price is not None else None,
         "deposit": float(item.deposit) if item.deposit is not None else None,
+        "rentalDays": None,
         "shippingMethod": item.shipping_method,
         "shippingQuote": float(item.shipping_quote) if item.shipping_quote is not None else None,
     }

--- a/fastapi/routes/notifications.py
+++ b/fastapi/routes/notifications.py
@@ -3,9 +3,9 @@ from sqlalchemy.orm import Session
 from core.dependencies import get_db, get_current_user
 from models.user import User
 from services.notification_service import NotificationService
+from utils.datetime import to_utc_iso
 
 router = APIRouter(prefix="/notifications", tags=["Notifications"])
-
 
 @router.get("/")
 def list_notifications(
@@ -21,7 +21,7 @@ def list_notifications(
             "title": n.title,
             "message": n.message,
             "is_read": n.is_read,
-            "created_at": n.created_at.isoformat() if n.created_at else None,
+            "created_at": to_utc_iso(n.created_at),
         }
         for n in notifications
     ]

--- a/fastapi/routes/payment_gateway.py
+++ b/fastapi/routes/payment_gateway.py
@@ -18,10 +18,9 @@ from models.payment_gateway import (
     StripeWebhookEvent
 )
 from typing import Optional
+from utils.datetime import to_utc_iso
 
 router = APIRouter(prefix="/payment_gateway", tags=["Payment_gateway"])
-
-# -------- Helper --------
 
 
 
@@ -167,8 +166,8 @@ def get_refunds_for_order(order_id: str, db: Session = Depends(get_db)):
                 "currency": r.currency,
                 "status": r.status,
                 "reason": r.reason,
-                "created_at": r.created_at,
-                "updated_at": r.updated_at,
+                "created_at": to_utc_iso(r.created_at),
+                "updated_at": to_utc_iso(r.updated_at),
             }
             for r in refunds
         ],
@@ -251,21 +250,21 @@ def get_user_refunds(user_id: str, db: Session = Depends(get_db)):
                 "status": r.status,
                 "reason": r.reason,
                 "refund_type": refund_type,
-                "created_at": r.created_at.isoformat() if r.created_at else None,
-                "updated_at": r.updated_at.isoformat() if r.updated_at else None,
+                "created_at": to_utc_iso(r.created_at),
+                "updated_at": to_utc_iso(r.updated_at),
                 "order": {
                     "order_id": order.id,
                     "status": order.status,
                     "book_titles": book_titles,
-                    "created_at": order.created_at.isoformat() if order.created_at else None,
-                    "canceled_at": order.canceled_at.isoformat() if order.canceled_at else None,
+                    "created_at": to_utc_iso(order.created_at),
+                    "canceled_at": to_utc_iso(order.canceled_at),
                 },
                 "timeline": [
                     {
                         "event": log.event_type,
                         "actor": log.actor,
                         "message": log.message,
-                        "timestamp": log.created_at.isoformat() if log.created_at else None,
+                        "timestamp": to_utc_iso(log.created_at),
                     }
                     for log in logs
                 ],
@@ -402,7 +401,7 @@ def get_admin_refunds(
                     "dispute_id": d.dispute_id,
                     "reason": d.reason,
                     "status": d.status,
-                    "created_at": d.created_at.isoformat() if d.created_at else None,
+                    "created_at": to_utc_iso(d.created_at),
                 }
                 for d in payment_disputes
             ]
@@ -433,8 +432,8 @@ def get_admin_refunds(
             "reason": r.reason,
             "refund_type": r_type,
             "trigger": trigger,
-            "created_at": r.created_at.isoformat() if r.created_at else None,
-            "updated_at": r.updated_at.isoformat() if r.updated_at else None,
+            "created_at": to_utc_iso(r.created_at),
+            "updated_at": to_utc_iso(r.updated_at),
             "order": {
                 "order_id": order.id if order else None,
                 "status": order.status if order else None,
@@ -522,7 +521,7 @@ def get_admin_refund_detail(
                     "event": log.event_type,
                     "actor": log.actor,
                     "message": log.message,
-                    "timestamp": log.created_at.isoformat() if log.created_at else None,
+                    "timestamp": to_utc_iso(log.created_at),
                 }
                 for log in logs
             ]
@@ -538,7 +537,7 @@ def get_admin_refund_detail(
                 "note": d.note,
                 "status": d.status,
                 "deduction": d.deduction,
-                "created_at": d.created_at.isoformat() if d.created_at else None,
+                "created_at": to_utc_iso(d.created_at),
             }
             for d in payment_disputes
         ]
@@ -583,8 +582,8 @@ def get_admin_refund_detail(
         "reason": refund.reason,
         "refund_type": r_type,
         "trigger": trigger,
-        "created_at": refund.created_at.isoformat() if refund.created_at else None,
-        "updated_at": refund.updated_at.isoformat() if refund.updated_at else None,
+        "created_at": to_utc_iso(refund.created_at),
+        "updated_at": to_utc_iso(refund.updated_at),
         "payment": {
             "payment_id": payment.payment_id,
             "amount": payment.amount,
@@ -603,8 +602,8 @@ def get_admin_refund_detail(
             "order_id": order.id,
             "status": order.status,
             "book_titles": book_titles,
-            "created_at": order.created_at.isoformat() if order.created_at else None,
-            "canceled_at": order.canceled_at.isoformat() if order.canceled_at else None,
+            "created_at": to_utc_iso(order.created_at),
+            "canceled_at": to_utc_iso(order.canceled_at),
         } if order else None,
         "borrower": {
             "user_id": borrower.user_id,

--- a/fastapi/services/book_service.py
+++ b/fastapi/services/book_service.py
@@ -10,7 +10,7 @@ from sqlalchemy import select, func, or_, and_
 
 from models.book import Book
 
-ALLOWED_DEPOSIT_INCOME_PERCENTAGES = {0, 5, 10, 15, 20}
+ALLOWED_DEPOSIT_INCOME_PERCENTAGES = set(range(0, 21))
 
 
 def _normalize_deposit_income_percentage(value: Any) -> int:
@@ -53,7 +53,7 @@ class BookService:
             isbn=payload.get("isbn"),
             tags=payload.get("tags") or [],
             publish_year=payload.get("publish_year"),
-            max_lending_days=int(payload.get("max_lending_days", 14)),
+            max_lending_days=min(int(payload.get("max_lending_days", 30)), 30),
             deposit_income_percentage=_normalize_deposit_income_percentage(
                 payload.get("deposit_income_percentage", 0)
             ),

--- a/fastapi/services/cart_service.py
+++ b/fastapi/services/cart_service.py
@@ -2,6 +2,7 @@ import uuid
 from sqlalchemy.orm import Session
 from fastapi import HTTPException
 from models.cart import Cart, CartItem
+from models.book import Book
 from typing import List
 
 def get_cart_with_items(db: Session, user_id: str) -> Cart:
@@ -22,6 +23,12 @@ def add_cart_item(
     price: float = None,
     deposit: float = None,
 ) -> CartItem:
+    book = db.query(Book).filter(Book.id == book_id).first()
+    if not book:
+        raise HTTPException(status_code=404, detail="Book not found")
+    if book.owner_id == user_id or owner_id == user_id:
+        raise HTTPException(status_code=400, detail="You cannot request your own listed book")
+
     cart = get_cart_with_items(db, user_id)
     existing = (
         db.query(CartItem)

--- a/fastapi/services/checkout_service.py
+++ b/fastapi/services/checkout_service.py
@@ -10,7 +10,7 @@ from models.user import User
 
 BASE_URL = "https://digitalapi.auspost.com.au/postage/parcel/domestic/calculate.json"
 AUSPOST_API_KEY = os.getenv("AUSPOST_CALCULATE_API_KEY")
-PLATFORM_SERVICE_FEE_RATE = 0.05
+PLATFORM_SERVICE_FEE_AMOUNT = 2.0
 
 
 # -------- Shipping fee calculator --------
@@ -162,11 +162,10 @@ async def _apply_checkout_data(db: Session, checkout: Checkout, checkoutIn: Chec
             priceTotal += float(itemIn.price)
         elif itemIn.actionType.upper() == "BORROW" and itemIn.deposit:
             depositTotal += float(itemIn.deposit)
-            ownerIncomeTotal += (
-                float(itemIn.deposit)
-                * float(getattr(book, "deposit_income_percentage", 0) or 0)
-                / 100.0
-            )
+            rental_rate = float(getattr(book, "deposit_income_percentage", 0) or 0) / 10.0
+            rental_days = max(0, int(getattr(itemIn, "rentalDays", 0) or 0))
+            rental_fee = rental_rate * rental_days if rental_days > 0 else float(itemIn.price or 0)
+            ownerIncomeTotal += rental_fee
 
         item = CheckoutItem(
             item_id=str(uuid.uuid4()),
@@ -174,7 +173,11 @@ async def _apply_checkout_data(db: Session, checkout: Checkout, checkoutIn: Chec
             book_id=itemIn.bookId,
             owner_id=itemIn.ownerId,
             action_type=itemIn.actionType,
-            price=itemIn.price,
+            price=(
+                ((float(getattr(book, "deposit_income_percentage", 0) or 0) / 10.0) * max(0, int(getattr(itemIn, "rentalDays", 0) or 0)))
+                if itemIn.actionType.upper() == "BORROW"
+                else itemIn.price
+            ),
             deposit=itemIn.deposit,
             shipping_method=itemIn.shippingMethod,
             shipping_quote=0.0,
@@ -195,9 +198,9 @@ async def _apply_checkout_data(db: Session, checkout: Checkout, checkoutIn: Chec
                 shippingFeeTotal += float(item.shipping_quote)
                 processedOwners.add(item.owner_id)
 
-    # Step D: platform service fee = (item total incl. shipping) * 5%
+    # Step D: platform service fee is fixed at $2 per transaction.
     subtotalBeforeServiceFee = depositTotal + ownerIncomeTotal + priceTotal + shippingFeeTotal
-    serviceFeeAmount = subtotalBeforeServiceFee * PLATFORM_SERVICE_FEE_RATE
+    serviceFeeAmount = PLATFORM_SERVICE_FEE_AMOUNT if checkout.items else 0.0
 
     # Step E: update checkout totals
     checkout.deposit = depositTotal

--- a/fastapi/services/email_service.py
+++ b/fastapi/services/email_service.py
@@ -165,7 +165,7 @@ def send_order_confirmation_receipt_email(
             f"- Order {order['order_id']} | {order['action_type']} | "
             f"{order['shipping_method']} | Books: {books} | "
             f"Item amount: ${order['deposit_or_sale_amount']:.2f} | "
-            f"Owner income: ${order.get('owner_income_amount', 0):.2f} | "
+            f"Rental fee: ${order.get('owner_income_amount', 0):.2f} | "
             f"Shipping: ${order['shipping_fee_amount']:.2f} | "
             f"Service fee: ${order['service_fee_amount']:.2f} | "
             f"Amount: ${order['total_paid_amount']:.2f}"

--- a/fastapi/services/order_service.py
+++ b/fastapi/services/order_service.py
@@ -21,7 +21,7 @@ from services.email_service import (
 )
 
 logger = logging.getLogger(__name__)
-PLATFORM_SERVICE_FEE_RATE = 0.05
+PLATFORM_SERVICE_FEE_AMOUNT = 2.0
 
 class OrderService:
     """
@@ -101,8 +101,8 @@ class OrderService:
 
     @staticmethod
     def _calculate_service_fee(base_amount: float) -> float:
-        """Platform service fee = 5% of the provided subtotal."""
-        return float(base_amount or 0) * PLATFORM_SERVICE_FEE_RATE
+        """Platform service fee is fixed at $2 per transaction."""
+        return PLATFORM_SERVICE_FEE_AMOUNT if float(base_amount or 0) > 0 else 0.0
 
     @staticmethod
     def _is_post_shipping(shipping_method: Optional[str]) -> bool:
@@ -150,7 +150,7 @@ class OrderService:
         """
         results = []
 
-        for order_items in orders_data:
+        for index, order_items in enumerate(orders_data):
             if not order_items:
                 continue
 
@@ -166,12 +166,7 @@ class OrderService:
                 elif item.action_type.lower() == "borrow":
                     # for borrowing, use deposit
                     deposit_or_sale_amount += float(item.deposit or 0)
-                    book = db.query(Book).filter(Book.id == item.book_id).first()
-                    owner_income_amount += (
-                        float(item.deposit or 0)
-                        * float(getattr(book, "deposit_income_percentage", 0) or 0)
-                        / 100.0
-                    )
+                    owner_income_amount += float(item.price or 0)
 
             # Calculate shipping fee
             post_items = [item for item in order_items if OrderService._is_post_shipping(item.shipping_method)]
@@ -182,7 +177,7 @@ class OrderService:
 
             # Platform service fee = (item total incl. shipping) * 5%
             service_fee_base = deposit_or_sale_amount + owner_income_amount + shipping_out_fee_amount
-            service_fee_amount = OrderService._calculate_service_fee(service_fee_base)
+            service_fee_amount = OrderService._calculate_service_fee(service_fee_base) if index == 0 else 0.0
 
             # keep original item
             results.append({
@@ -348,9 +343,9 @@ class OrderService:
                 "action_type": order.action_type,
                 "total_paid_amount": float(order.total_paid_amount),
                 "books": books_info,
-                "create_at": order.created_at,
-                "due_at": order.due_at,
-                "completed_at": order.completed_at,
+                "create_at": Order._to_utc_iso(order.created_at),
+                "due_at": Order._to_utc_iso(order.due_at),
+                "completed_at": Order._to_utc_iso(order.completed_at),
                 "owner_id": order.owner_id,
                 "borrower_id": order.borrower_id,
                 "shipping_out_tracking_number": order.shipping_out_tracking_number,

--- a/fastapi/services/payment_gateway_service.py
+++ b/fastapi/services/payment_gateway_service.py
@@ -209,6 +209,7 @@ def initiate_payment(data: dict, db: Session):
             action_types.add(item.action_type)
             if item.action_type == "BORROW":
                 deposit_total += int((item.deposit or 0) * 100)
+                purchase_total += int((item.price or 0) * 100)
             elif item.action_type == "PURCHASE":
                 purchase_total += int((item.price or 0) * 100)
 
@@ -983,7 +984,7 @@ def build_payment_splits_for_orders(db: Session, payment_id: str, orders: List[O
     """
     Create a PaymentSplit for each order:
       - Purchase: transfer = sale price + shipping; service fee kept by platform
-      - Borrow: transfer = shipping (deposit kept by platform, refunded after return)
+      - Borrow: transfer = rental fee + shipping (deposit kept by platform, refunded after return)
     """
     for order in orders:
         owner_acct = (order.owner.stripe_account_id if order.owner else None)
@@ -1000,7 +1001,7 @@ def build_payment_splits_for_orders(db: Session, payment_id: str, orders: List[O
             transfer_cents = deposit_or_sale_cents + shipping_cents
             deposit_cents = 0
         else:
-            transfer_cents = shipping_cents
+            transfer_cents = to_cents((order.owner_income_amount or 0)) + shipping_cents
             deposit_cents = deposit_or_sale_cents
 
         sp = PaymentSplit(

--- a/fastapi/utils/datetime.py
+++ b/fastapi/utils/datetime.py
@@ -1,0 +1,11 @@
+from datetime import datetime, timezone
+
+
+def to_utc_iso(value: datetime | None) -> str | None:
+    if not value:
+        return None
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    else:
+        value = value.astimezone(timezone.utc)
+    return value.isoformat()

--- a/frontendNext/app/books/[id]/page.tsx
+++ b/frontendNext/app/books/[id]/page.tsx
@@ -41,14 +41,12 @@ export default function BookDetailPage() {
   const [book, setBook] = useState<Book | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const depositIncome =
-    ((Number(book?.deposit) || 0) * (Number(book?.depositIncomePercentage) || 0)) / 100;
-
   const [currentUser, setCurrentUser] = useState<User | null>(null);
   const [owner, setOwner] = useState<User | null>(null);
 
   const { cart, fetchCart, addToCart } = useCartStore();
   const alreadyInCart = cart.some((item) => item.id === book?.id);
+  const isOwnBook = !!(currentUser?.id && book?.ownerId && currentUser.id === book.ownerId);
 
   const distance = useMemo(() => {
     if (!owner?.coordinates || !currentUser?.coordinates) return 0;
@@ -272,6 +270,11 @@ const [ownerRating, setOwnerRating] = useState<RatingStats>({
                         return;
                       }
 
+                      if (isOwnBook) {
+                        toast.error("You can't request your own listed book");
+                        return;
+                      }
+
                       // Already in cart
                       if (alreadyInCart) {
                         toast.error("This book is already in your cart");
@@ -292,12 +295,14 @@ const [ownerRating, setOwnerRating] = useState<RatingStats>({
                     }}
                     className="w-full flex items-center justify-center space-x-2"
                     disabled={
-                      alreadyInCart || book.status !== "listed" || (!book.canRent && !book.canSell)
+                      isOwnBook || alreadyInCart || book.status !== "listed" || (!book.canRent && !book.canSell)
                     }
                   >
                     <ShoppingBag className="w-4 h-4" />
                     <span>
-                      {alreadyInCart
+                      {isOwnBook
+                        ? "Your Listing"
+                        : alreadyInCart
                         ? "Already in Cart"
                         : book.status !== "listed"
                           ? "Unlisted"
@@ -402,7 +407,7 @@ const [ownerRating, setOwnerRating] = useState<RatingStats>({
                     <div className="flex items-center justify-between">
                       <span className="text-gray-500 flex items-center gap-1">
                         <Clock className="w-4 h-4" />
-                        Max lending:
+                        Maximum rental duration:
                       </span>
                       <span className="font-medium">{book.maxLendingDays} days</span>
                     </div>
@@ -415,6 +420,7 @@ const [ownerRating, setOwnerRating] = useState<RatingStats>({
                     </span>
                     <span className="font-medium">{getDeliveryLabel(book.deliveryMethod)}</span>
                   </div>
+
                 </div>
 
                 {/* Price Info (only show if applicable) */}
@@ -436,9 +442,6 @@ const [ownerRating, setOwnerRating] = useState<RatingStats>({
                           <p className="text-xs text-gray-500 mt-1">
                             * Deposit is refundable upon timely return of the book in good condition.
                           </p>
-                          <p className="text-xs text-amber-700 mt-1">
-                            Estimated Income: ${depositIncome.toFixed(2)} ({book.depositIncomePercentage ?? 0}% of deposit fee)
-                          </p>
                         </div>
                       )}
 
@@ -456,6 +459,38 @@ const [ownerRating, setOwnerRating] = useState<RatingStats>({
                           <p className="text-xs text-gray-500 mt-1">
                             * Sale Price is the final purchase price (non-refundable).
                           </p>
+                        </div>
+                      )}
+
+                      {book.canRent && !book.canSell && (
+                        <div className="flex flex-col justify-start">
+                          <div className="flex justify-between">
+                            <p className="text-sm text-gray-500">Rental/Day:</p>
+                            <p className="font-bold text-orange-600">
+                              ${(Number(book.depositIncomePercentage ?? 0) / 10).toFixed(1)}/day
+                            </p>
+                          </div>
+                          <div>
+                            <p className="text-xs text-gray-500 mt-1">
+                              Duration is chosen by the borrower at checkout, up to {book.maxLendingDays} days.
+                            </p>
+                          </div>
+                        </div>
+                      )}
+
+                      {book.canRent && book.canSell && (
+                        <div className="flex flex-col">
+                          <div className="flex justify-between">
+                            <p className="text-sm text-gray-500">Rental/Day:</p>
+                            <p className="font-bold text-orange-600">
+                              ${(Number(book.depositIncomePercentage ?? 0) / 10).toFixed(1)}/day
+                            </p>
+                          </div>
+                          <div>
+                            <p className="text-xs text-gray-500 mt-1">
+                              Duration is chosen by the borrower at checkout, up to {book.maxLendingDays} days.
+                            </p>
+                          </div>
                         </div>
                       )}
                     </div>

--- a/frontendNext/app/borrowing/[id]/history/page.tsx
+++ b/frontendNext/app/borrowing/[id]/history/page.tsx
@@ -13,6 +13,7 @@ import { getOrdersByBookId } from "@/utils/borrowingOrders";
 import { getBookById } from "@/utils/books";
 import { getUserById } from "@/utils/auth";
 import type { Order as ApiOrder } from "@/utils/borrowingOrders";
+import { formatLocalDateTime } from "@/utils/datetime";
 
 const STATUS_META: Record<string, { label: string; className: string }> = {
   PENDING_PAYMENT: { label: "Pending Payment", className: "text-amber-600" },
@@ -24,7 +25,7 @@ const STATUS_META: Record<string, { label: string; className: string }> = {
   CANCELED: { label: "Canceled", className: "text-gray-400" },
 };
 
-const fmtDate = (v?: string) => (v ? new Date(v).toLocaleString() : "—");
+const fmtDate = (v?: string) => formatLocalDateTime(v);
 
 export default function BorrowHistoryPage() {
   const params = useParams();

--- a/frontendNext/app/borrowing/[id]/page.tsx
+++ b/frontendNext/app/borrowing/[id]/page.tsx
@@ -12,6 +12,7 @@ import { toast } from "sonner";
 import { getApiUrl, getToken, getCurrentUser } from "@/utils/auth";
 import { getReviewsByOrder } from "@/utils/review";
 import { getRefundsForOrder, cancelOrderWithRefund } from "@/utils/payments";
+import { formatLocalDateTime } from "@/utils/datetime";
 
 import type { OrderStatus, ApiOrder } from "@/app/types/order";
 import type { User } from "@/app/types/user";
@@ -29,7 +30,7 @@ const STATUS_META: Record<OrderStatus, { label: string; className: string }> = {
 const fmtAUD = (amount?: number) =>
   typeof amount === "number" ? `A$ ${amount.toFixed(2)}` : "—";
 
-const fmtDate = (v?: string | null) => (v ? new Date(v).toLocaleString() : "—");
+const fmtDate = (v?: string | null) => formatLocalDateTime(v);
 
 const TX_STAGE_META = {
   pending: { label: "Pending", className: "bg-amber-100 text-amber-800" },
@@ -52,6 +53,7 @@ const fetchOrderDetails = async (orderId: string): Promise<ApiOrder | null> => {
 
     const response = await fetch(`${apiUrl}/api/v1/orders/${orderId}`, {
       headers: { Authorization: `Bearer ${token}` },
+      cache: "no-store",
     });
 
     if (!response.ok) {
@@ -414,9 +416,35 @@ export default function OrderDetailPage() {
 
       toast.success("Shipment confirmed successfully");
 
+      setOrder((prev) =>
+        prev
+          ? {
+              ...prev,
+              shippingOutTrackingNumber:
+                prev.status === "PENDING_SHIPMENT"
+                  ? trackingNumber.trim()
+                  : prev.shippingOutTrackingNumber,
+              shippingReturnTrackingNumber:
+                prev.status === "BORROWING" || prev.status === "OVERDUE"
+                  ? trackingNumber.trim()
+                  : prev.shippingReturnTrackingNumber,
+              status:
+                prev.status === "BORROWING" || prev.status === "OVERDUE"
+                  ? "RETURNED"
+                  : prev.status,
+            }
+          : prev
+      );
+
       const updatedOrder = await fetchOrderDetails(order.id);
       if (updatedOrder) {
-        setOrder(updatedOrder);
+        setOrder((prev) => ({
+          ...updatedOrder,
+          shippingOutTrackingNumber:
+            updatedOrder.shippingOutTrackingNumber || prev?.shippingOutTrackingNumber || null,
+          shippingReturnTrackingNumber:
+            updatedOrder.shippingReturnTrackingNumber || prev?.shippingReturnTrackingNumber || null,
+        }));
       }
       // Trigger notification badge refresh in Header
       window.dispatchEvent(new Event("notif-update"));
@@ -631,7 +659,7 @@ export default function OrderDetailPage() {
             </div>
             {(order.ownerIncomeAmount || 0) > 0 && (
               <div className="flex justify-between">
-                <span>Owner Income</span>
+                <span>Rental Fee</span>
                 <span className="font-medium">
                   {fmtAUD(order.ownerIncomeAmount)}
                 </span>
@@ -805,7 +833,7 @@ export default function OrderDetailPage() {
               className="bg-black text-white hover:bg-gray-800"
               onClick={() => setShipModalOpen(true)}
             >
-              {order.shippingOutTrackingNumber ? "Update Shipment" : "Ship"}
+              {order.shippingOutTrackingNumber ? "Update Shipping" : "Ship"}
             </Button>
           )}
 

--- a/frontendNext/app/borrowing/page.tsx
+++ b/frontendNext/app/borrowing/page.tsx
@@ -12,6 +12,7 @@ import { EmptyState, ErrorState, LoadingState } from "../components/ui/AsyncStat
 import type { OrderStatus } from "@/app/types/order";
 import { confirmBorrowerReceived, getBorrowingOrders, type Order } from "@/utils/borrowingOrders";
 import { getCurrentUser } from "@/utils/auth";
+import { formatLocalDateTime } from "@/utils/datetime";
 
 const STATUS_META: Record<OrderStatus, { label: string; className: string }> = {
   PENDING_PAYMENT: { label: "Pending Payment", className: "text-amber-600" },
@@ -170,14 +171,7 @@ export default function OrderListPage() {
   ] as const;
 
   // Format date helper
-  const fmtDate = (v?: string) => {
-    if (!v) return "—";
-    try {
-      return new Date(v).toLocaleString();
-    } catch {
-      return "Invalid date";
-    }
-  };
+  const fmtDate = (v?: string) => formatLocalDateTime(v);
 
   return (
     <div className="flex h-full">

--- a/frontendNext/app/checkout/page.tsx
+++ b/frontendNext/app/checkout/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
+import { CircleHelp } from "lucide-react";
 import Card from "@/app/components/ui/Card";
 import Button from "@/app/components/ui/Button";
 import Input from "@/app/components/ui/Input";
@@ -45,6 +46,8 @@ interface CheckoutItem {
   actionType: "BORROW" | "PURCHASE";
   price?: number;
   deposit?: number;
+  rentalDays?: number;
+  rentalPerDay?: number;
   depositIncomePercentage?: number;
   deliveryMethod?: "post" | "pickup" | "both";
   shippingMethod?: "post" | "pickup";
@@ -56,8 +59,34 @@ type PaymentConfirmFormProps = {
   onSuccess?: () => void;
 };
 
-const TEST_DESTINATION_ACCOUNT_ID =
-  process.env.NEXT_PUBLIC_STRIPE_TEST_DESTINATION_ACCOUNT_ID || "acct_1TGXxXQvCdOoVRC6";
+const depositSummaryTooltipText =
+  "Deposits are refundable after the book is returned in the agreed condition.";
+const shippingSummaryTooltipText =
+  "Shipping is charged per owner based on the delivery option and quote you select.";
+const rentalSummaryTooltipText =
+  "Rental fee is calculated automatically as rental/day multiplied by rental days.";
+const serviceFeeTooltipText =
+  "This is the platform's fixed service fee for the transaction.";
+
+function SummaryLabel({ label, tooltip }: { label: string; tooltip?: string }) {
+  if (!tooltip) return <span>{label}</span>;
+
+  return (
+    <span className="flex items-center gap-1.5">
+      <span>{label}</span>
+        <span className="group relative inline-flex items-center">
+          <CircleHelp
+            className="h-4 w-4 cursor-help text-gray-400"
+            aria-label={tooltip}
+            title={tooltip}
+          />
+        <span className="pointer-events-none absolute left-0 top-full z-10 mt-2 w-56 rounded-md bg-gray-900 px-3 py-2 text-xs font-normal leading-5 text-white opacity-0 shadow-lg transition-opacity duration-150 group-hover:opacity-100 group-focus-within:opacity-100">
+          {tooltip}
+        </span>
+      </span>
+    </span>
+  );
+}
 
 function PaymentConfirmForm({ clientSecret, onSuccess }: PaymentConfirmFormProps) {
   const stripe = useStripe();
@@ -120,7 +149,6 @@ function PaymentConfirmForm({ clientSecret, onSuccess }: PaymentConfirmFormProps
 
 export default function CheckoutPage() {
   const router = useRouter();
-  const [globalShippingChoice, setGlobalShippingChoice] = useState<"standard" | "express" | null>("standard");
   const [currentUser, setCurrentUser] = useState<User | null>(null);
   const [checkouts, setCheckouts] = useState<any[]>([]);
   const [ownersMap, setOwnersMap] = useState<Record<string, { name: string; zipCode: string; stripeAccountId?: string | null }>>({});
@@ -137,8 +165,6 @@ export default function CheckoutPage() {
   const [selectedQuoteByOwner, setSelectedQuoteByOwner] = useState<Record<string, ShippingQuote>>({});
   const [isEditing, setIsEditing] = useState(false);
 
-  const [rebuilding, setRebuilding] = useState(false);
-  const [loading, setLoading] = useState(false);
   const [userLoaded, setUserLoaded] = useState(false);
   const [initializingCheckout, setInitializingCheckout] = useState(true);
   const [initError, setInitError] = useState<string | null>(null);
@@ -157,7 +183,7 @@ export default function CheckoutPage() {
   const [paying, setPaying] = useState(false);
   const [showDonationModal, setShowDonationModal] = useState(false);
   const [donationAmount, setDonationAmount] = useState<string>("");
-  const [deliveryMethodSaved, setDeliveryMethodSaved] = useState(false);
+  const [rentalDaysByBook, setRentalDaysByBook] = useState<Record<string, number>>({});
 
 
   // 1. load current user, fill address info
@@ -246,47 +272,38 @@ export default function CheckoutPage() {
               ...it,
               titleOr: book?.titleOr,
               deliveryMethod: book?.deliveryMethod,
+              rentalPerDay: (book?.depositIncomePercentage ?? 0) / 10,
               depositIncomePercentage: book?.depositIncomePercentage ?? 0,
+              rentalDays:
+                it.actionType === "BORROW" && Number(book?.depositIncomePercentage ?? 0) > 0
+                  ? Math.max(1, Math.round(Number(it.price ?? 0) / (Number(book?.depositIncomePercentage ?? 0) / 10)))
+                  : 1,
             };
           } catch {
-            return { ...it, titleOr: "Unknown Book", deliveryMethod: "", depositIncomePercentage: 0 };
+            return { ...it, titleOr: "Unknown Book", deliveryMethod: "", depositIncomePercentage: 0, rentalPerDay: 0, rentalDays: 1 };
           }
         })
       );
       setFullItems(results);
-
-      // initiate itemShipping
-      const next: Record<string, DeliveryChoice | ""> = {};
-      for (const b of results) {
-        if (b.deliveryMethod === "post") {
-          next[b.bookId] = "post";
-        } else if (b.deliveryMethod === "pickup") {
-          next[b.bookId] = "pickup";
-        } else {
-          next[b.bookId] = b.shippingMethod || ""; // both 或 未设置时，保持空，交给用户选择
+      setRentalDaysByBook((prev) => {
+        const next = { ...prev };
+        for (const item of results) {
+          if (item.actionType === "BORROW" && !next[item.bookId]) {
+            next[item.bookId] = Math.min(30, Math.max(1, Number(item.rentalDays || 1)));
+          }
         }
-      }
-      setItemShipping(next);
+        return next;
+      });
+
+      // Preserve the user's previous choice after checkout rebuilds.
+      setItemShipping((prev) => {
+        const next: Record<string, DeliveryChoice | ""> = {};
+        for (const b of results) {
+          next[b.bookId] = prev[b.bookId] ?? "";
+        }
+        return next;
+      });
     })();
-  }, [items]);
-
-  // 4. init shipping state
-  useEffect(() => {
-    if (!items.length || Object.keys(itemShipping).length > 0) return;
-    setItemShipping(Object.fromEntries(items.map((b) => [b.bookId, ""])) as Record<string, DeliveryChoice | "">);
-  }, [items]);
-
-  // ---------- useEffect initialize shipping ----------
-  useEffect(() => {
-    if (!items.length) return;
-
-    if (Object.keys(itemShipping).length > 0) return;
-
-    const next: Record<string, "post" | "pickup" | ""> = {};
-    for (const b of items) {
-      next[b.bookId] = ""; // default empty
-    }
-    setItemShipping(next);
   }, [items]);
 
   // save address
@@ -304,15 +321,13 @@ export default function CheckoutPage() {
       phoneNumber: currentCheckout.phone,
     });
 
-    const cleaned = Object.fromEntries(currentCheckout.items.map((it: any) => [it.bookId, it.shippingMethod]));
-    const newCheckout = await rebuildCheckout(currentUser, fullItems, cleaned, selectedQuoteByOwner);
-    setCheckouts([newCheckout]);
+    await refreshCheckoutForSelections(itemShipping, rentalDaysByBook);
     setIsEditing(false);
     setActionNotice("Address saved.");
   };
 
   // ---------- Get quotes per owner for DELIVERY items ----------
-  async function requestQuotes() {
+  async function requestQuotes(shippingChoices: Record<string, DeliveryChoice | "">) {
     if (!currentCheckout) return;
     console.log("[requestQuotes] start... currentCheckout:", currentCheckout);
 
@@ -322,7 +337,7 @@ export default function CheckoutPage() {
 
     const deliveryGroups: Record<string, any[]> = {};
     for (const b of items) {
-      if (itemShipping[b.bookId] === "post") {
+      if (shippingChoices[b.bookId] === "post") {
         (deliveryGroups[b.ownerId] ||= []).push(b);
       }
     }
@@ -373,63 +388,65 @@ export default function CheckoutPage() {
       }
     }
     setQuotesByOwner(result);
-    // default Standard
-    const defaults: Record<string, ShippingQuote> = {};
+    const mergedSelections: Record<string, ShippingQuote> = {};
     for (const [ownerId, quotes] of Object.entries(result)) {
+      const current = selectedQuoteByOwner[ownerId];
+      const matched = current
+        ? quotes.find((q) => q.serviceLevel === current.serviceLevel)
+        : undefined;
       const std = quotes.find((q) => q.serviceLevel === "Standard");
-      if (std) defaults[ownerId] = std;
+      if (matched) {
+        mergedSelections[ownerId] = matched;
+      } else if (std) {
+        mergedSelections[ownerId] = std;
+      }
     }
-    setSelectedQuoteByOwner(defaults);
-
-    setGlobalShippingChoice("standard");
-
-    // rebuildCheckout
-    if (Object.keys(defaults).length > 0) {
-      const cleaned = Object.fromEntries(
-        fullItems.map((it) => [it.bookId, itemShipping[it.bookId]])
-      ) as Record<string, DeliveryChoice>;
-      const newCheckout = await rebuildCheckout(currentUser!, fullItems, cleaned, defaults);
-      setCheckouts([newCheckout]);
-    }
-  }
-
-  // save delivery method
-  const saveDeliveryMethod = async () => {
-    setActionError(null);
-    setActionNotice(null);
-    const unselected = items.filter((b) => !itemShipping[b.bookId]);
-    if (unselected.length > 0) {
-      setActionError("Please select delivery method for all items before saving.");
-      return;
-    }
-
-    const cleaned = Object.fromEntries(
-      Object.entries(itemShipping).filter(([, v]) => v)
-    ) as Record<string, DeliveryChoice>;
-
-    setItemShipping(cleaned);
-    console.log("[saveDeliveryMethod] calling requestQuotes...");
-
-    await requestQuotes();
-    setDeliveryMethodSaved(true);
-    setActionNotice("Delivery methods saved.");
+    setSelectedQuoteByOwner(mergedSelections);
+    return mergedSelections;
   };
+
+  async function refreshCheckoutForSelections(
+    shippingChoices: Record<string, DeliveryChoice | "">,
+    rentalDays: Record<string, number>
+  ) {
+    if (!currentUser) return;
+
+    const hasUnselected = fullItems.some((item) => !shippingChoices[item.bookId]);
+    if (hasUnselected) return;
+
+    const quotes = await requestQuotes(shippingChoices);
+    const cleaned = Object.fromEntries(
+      Object.entries(shippingChoices).filter(([, v]) => v)
+    ) as Record<string, DeliveryChoice>;
+    const newCheckout = await rebuildCheckout(currentUser, fullItems, cleaned, quotes || {}, rentalDays);
+    setCheckouts([newCheckout]);
+  }
 
 
   // ---------- Handlers ----------
-  const setChoice = (bookId: string, value: DeliveryChoice) => {
-    setItemShipping(prev => {
-      const next = { ...prev, [bookId]: value };
-      return next;
-    });
-    // Mark delivery as unsaved when user changes selection
-    setDeliveryMethodSaved(false);
+  const setChoice = async (bookId: string, value: DeliveryChoice) => {
+    setActionError(null);
+    setActionNotice(null);
+    const nextShipping = { ...itemShipping, [bookId]: value };
+    setItemShipping(nextShipping);
+    await refreshCheckoutForSelections(nextShipping, rentalDaysByBook);
+  };
+
+  const setRentalDays = async (bookId: string, value: number) => {
+    setActionError(null);
+    setActionNotice(null);
+    const nextRentalDays = {
+      ...rentalDaysByBook,
+      [bookId]: Math.min(30, Math.max(1, value)),
+    };
+    setRentalDaysByBook(nextRentalDays);
+    await refreshCheckoutForSelections(itemShipping, nextRentalDays);
   };
 
 
   // initiate PaymentIntent，to get client_secret
   const startPayment = async (donation: number = 0) => {
-    const co = checkouts[0];
+    let co = checkouts[0];
     if (!co || !currentUser) return;
     setActionError(null);
 
@@ -448,6 +465,12 @@ export default function CheckoutPage() {
 
     try {
       setPaying(true);
+      const cleaned = Object.fromEntries(
+        fullItems.map((it) => [it.bookId, itemShipping[it.bookId]])
+      ) as Record<string, DeliveryChoice>;
+      co = await rebuildCheckout(currentUser, fullItems, cleaned, selectedQuoteByOwner, rentalDaysByBook);
+      setCheckouts([co]);
+
       const toCents = (n: number | undefined | null) =>
         Math.max(0, Math.round((n || 0) * 100));
       const totalAmount = co.totalDue + donation;
@@ -456,7 +479,7 @@ export default function CheckoutPage() {
         user_id: currentUser.id,
         amount: toCents(totalAmount),
         currency: "aud",
-        purchase: toCents(co.bookFee),
+        purchase: toCents((co.bookFee || 0) + (co.ownerIncomeAmount || 0)),
         deposit: toCents(co.deposit),
         shipping_fee: toCents(co.shippingFee),
         service_fee: toCents(co.serviceFee),
@@ -514,12 +537,6 @@ export default function CheckoutPage() {
     const unselected = items.filter((b) => !itemShipping[b.bookId]);
     if (unselected.length > 0) {
       setActionError("Please select delivery method for all items before checkout.");
-      return;
-    }
-
-    // Check if delivery methods have been saved
-    if (!deliveryMethodSaved) {
-      setActionError("Please save your delivery methods by clicking the 'Save Delivery Method' button.");
       return;
     }
 
@@ -598,12 +615,22 @@ export default function CheckoutPage() {
       return acc;
     }, {} as Record<string, CheckoutItem[]>)
   ));
-  const totalEstimatedIncome = fullItems.reduce((sum, item) => {
+  const totalRentalFee = fullItems.reduce((sum, item) => {
     if (item.actionType !== "BORROW") return sum;
-    const deposit = Number(item.deposit ?? 0);
-    const percentage = Number(item.depositIncomePercentage ?? 0);
-    return sum + (deposit * percentage) / 100;
+    const rentalPerDay = Number(item.rentalPerDay ?? item.depositIncomePercentage ?? 0);
+    const rentalDays = Number(rentalDaysByBook[item.bookId] ?? item.rentalDays ?? 1);
+    return sum + rentalPerDay * rentalDays;
   }, 0);
+  const purchaseTotal = fullItems.reduce((sum, item) => {
+    if (item.actionType !== "PURCHASE") return sum;
+    return sum + Number(item.price ?? 0);
+  }, 0);
+  const displayDeposit = Number(checkouts[0]?.deposit ?? 0);
+  const displayPurchaseFee = Number(checkouts[0]?.bookFee ?? purchaseTotal);
+  const displayRentalFee = totalRentalFee;
+  const displayShippingFee = Number(checkouts[0]?.shippingFee ?? 0);
+  const displayServiceFee = Number(checkouts[0]?.serviceFee ?? (items.length > 0 ? 2 : 0));
+  const displayTotalDue = displayDeposit + displayPurchaseFee + displayRentalFee + displayShippingFee + displayServiceFee;
 
   return (
     <div className="max-w-6xl mx-auto p-4 sm:p-6 space-y-6">
@@ -648,8 +675,6 @@ export default function CheckoutPage() {
         <div className="p-4 space-y-3">
           <div className="flex items-center justify-between gap-2">
             <h2 className="text-lg font-semibold">Items & Delivery</h2>
-            <Button variant="outline" onClick={saveDeliveryMethod} className="text-sm">Save Delivery Method</Button>
-
           </div>
 
           {/* Items group */}
@@ -671,111 +696,121 @@ export default function CheckoutPage() {
                                 Trading Way: {b.actionType === "BORROW" ? "Borrow" : "Purchase"}
                               </span>
                             </div>
-                            {b.actionType === "BORROW" && (
-                              <div className="text-sm text-amber-700 mt-1">
-                                Estimated Income: ${(
-                                  (Number(b.deposit ?? 0) * Number(b.depositIncomePercentage ?? 0)) / 100
-                                ).toFixed(2)} ({b.depositIncomePercentage ?? 0}% of deposit)
-                              </div>
-                            )}
                           </div>
 
-                          {/* Post / Pickup select */}
+                        </div>
+                        {b.actionType === "BORROW" && (
+                          <div className="mt-4 rounded-md border bg-white p-4 space-y-3">
+                            <div className="text-sm font-medium text-gray-800">Rental Details</div>
+                            <div className="flex flex-wrap items-center justify-between gap-4">
+                              <span className="text-sm text-amber-700">
+                                Rental/day: ${Number(b.rentalPerDay ?? b.depositIncomePercentage ?? 0).toFixed(2)} / day
+                              </span>
+                              <div className="flex items-center gap-2">
+                                <span className="text-sm text-gray-700">Rental Days:</span>
+                                <select
+                                  value={rentalDaysByBook[b.bookId] ?? 1}
+                                  onChange={(e) => void setRentalDays(b.bookId, Number(e.target.value))}
+                                  className="px-3 py-1 border rounded bg-white text-sm"
+                                >
+                                  {Array.from({ length: 30 }, (_, i) => i + 1).map((day) => (
+                                    <option key={day} value={day}>
+                                      {day} day{day > 1 ? "s" : ""}
+                                    </option>
+                                  ))}
+                                </select>
+                              </div>
+                              <span className="text-sm text-amber-700">
+                                Rental fee: $
+                                {(Number(b.rentalPerDay ?? b.depositIncomePercentage ?? 0) * Number(rentalDaysByBook[b.bookId] ?? 1)).toFixed(2)}
+                              </span>
+                            </div>
+                          </div>
+                        )}
+                        <div className="mt-4 rounded-md border bg-white p-4 space-y-3">
+                          <div className="text-sm font-medium text-gray-800">Delivery</div>
                           <div className="flex flex-wrap items-center gap-2">
                             <span className="text-sm text-gray-700">Delivery Method:</span>
-                            {b.deliveryMethod === "post" && (
-                              <span className="px-4 py-1 rounded bg-black text-white text-sm">Post</span>
-                            )}
-                            {b.deliveryMethod === "pickup" && (
-                              <span className="px-4 py-1 rounded bg-black text-white text-sm">Pickup</span>
-                            )}
-                            {b.deliveryMethod === "both" && (
-                              <select
-                                value={itemShipping[b.bookId]}
-                                onChange={(e) => setChoice(b.bookId, e.target.value as DeliveryChoice)}
-                                className="px-3 py-1 border rounded bg-white text-sm"
-                              >
-                                <option value="" disabled>-- Select option --</option>
+                            <select
+                              value={itemShipping[b.bookId]}
+                              onChange={(e) => void setChoice(b.bookId, e.target.value as DeliveryChoice)}
+                              className="px-3 py-1 border rounded bg-white text-sm"
+                            >
+                              <option value="" disabled>-- Select option --</option>
+                              {(b.deliveryMethod === "post" || b.deliveryMethod === "both") && (
                                 <option value="post">Post</option>
+                              )}
+                              {(b.deliveryMethod === "pickup" || b.deliveryMethod === "both") && (
                                 <option value="pickup">Pickup</option>
-                              </select>
-                            )}
+                              )}
+                            </select>
                           </div>
-                        </div>
+                          {itemShipping[b.bookId] === "pickup" && (
+                            <p className="text-sm text-green-700">
+                              Pickup is free. Details will be shared after order.
+                            </p>
+                          )}
+                          {itemShipping[b.bookId] === "post" && (
+                            <p className="text-sm text-orange-700">
+                              Shipping fee is calculated automatically.
+                            </p>
+                          )}
+                          {itemShipping[b.bookId] === "post" &&
+                            quotesByOwner[ownerId]?.length > 0 && (
+                              <div className="border-t pt-3">
+                                <h4 className="text-sm font-semibold mb-2 text-gray-800">
+                                  AusPost Shipping Quotes
+                                </h4>
+                                <div className="flex flex-wrap gap-2">
+                                  {quotesByOwner[ownerId].map((q) => {
+                                    const choiceKey = q.serviceLevel === "Standard" ? "standard" : "express";
+                                    return (
+                                      <button
+                                        key={q.id}
+                                        type="button"
+                                        onClick={async () => {
+                                          // 所有 owner 都选择相同 serviceLevel
+                                          const updated: Record<string, ShippingQuote> = {};
+                                          for (const [oid, quotes] of Object.entries(quotesByOwner)) {
+                                            const match = quotes.find(
+                                              (x) => x.serviceLevel?.toLowerCase() === choiceKey
+                                            );
+                                            if (match) {
+                                              updated[oid] = {
+                                                ...match,
+                                                serviceCode: choiceKey === "express"
+                                                  ? "AUS_PARCEL_EXPRESS"
+                                                  : "AUS_PARCEL_REGULAR",
+                                              } as any;
+                                            }
+                                          }
+                                          setSelectedQuoteByOwner(updated);
 
-                        {/* Pickup hint */}
-                        {itemShipping[b.bookId] === "pickup" && (
-                          <p className="text-sm text-green-700 mt-2">
-                            Pickup is free. Details will be shared after order.
-                          </p>
-                        )}
-                        {/* Delivery hint */}
-                        {itemShipping[b.bookId] === "post" && (
-                          <p className="text-sm text-orange-700 mt-2">
-                            Shipping fees will be calculated after Save Delivery Method.
-                          </p>
-                        )}
+                                          const cleaned = Object.fromEntries(
+                                            fullItems.map((it) => [it.bookId, itemShipping[it.bookId]])
+                                          ) as Record<string, DeliveryChoice>;
+
+                                          const newCheckout = await rebuildCheckout(currentUser!, fullItems, cleaned, updated, rentalDaysByBook);
+                                          setCheckouts([newCheckout]);
+                                        }}
+                                        className={`px-3 py-2 rounded border text-sm ${selectedQuoteByOwner[ownerId]?.id === q.id
+                                          ? "bg-black text-white"
+                                          : "bg-white hover:bg-gray-50"
+                                          }`}
+                                      >
+                                        {q.carrier} {q.serviceLevel} • ${q.cost} • ETA {q.etaDays || "-"}d
+                                      </button>
+                                    );
+                                  })}
+                                </div>
+                              </div>
+                            )}
+                        </div>
 
 
                       </div>
                     ))}
                   </div>
-                  {/* Shipping Quotes（if chose delivery, display under this owner） */}
-                  {ownerItems.some((b) => itemShipping[b.bookId] === "post") &&
-                    quotesByOwner[ownerId]?.length > 0 && (
-                      <div className="mt-4 p-4 rounded-md border bg-white">
-                        <h4 className="text-sm font-semibold mb-2 text-gray-800">
-                          AusPost Shipping Quotes
-                        </h4>
-                        <div className="flex flex-wrap gap-2">
-                          {quotesByOwner[ownerId].map((q) => {
-                            const choiceKey = q.serviceLevel === "Standard" ? "standard" : "express";
-                            return (
-                              <button
-                                key={q.id}
-                                type="button"
-                                onClick={async () => {
-                                  setGlobalShippingChoice(choiceKey);
-
-                                  // 所有 owner 都选择相同 serviceLevel
-                                  const updated: Record<string, ShippingQuote> = {};
-                                  for (const [oid, quotes] of Object.entries(quotesByOwner)) {
-                                    const match = quotes.find(
-                                      (x) => x.serviceLevel?.toLowerCase() === choiceKey
-                                    );
-                                    if (match) {
-                                      updated[oid] = {
-                                        ...match,
-                                        serviceCode: choiceKey === "express"
-                                          ? "AUS_PARCEL_EXPRESS"
-                                          : "AUS_PARCEL_REGULAR",
-                                      } as any;
-                                    }
-                                  }
-                                  setSelectedQuoteByOwner(updated);
-
-                                  // rebuild checkout
-                                  const cleaned = Object.fromEntries(
-                                    fullItems.map((it) => [it.bookId, itemShipping[it.bookId]])
-                                  ) as Record<string, DeliveryChoice>;
-
-                                  const newCheckout = await rebuildCheckout(currentUser!, fullItems, cleaned, updated);
-                                  setCheckouts([newCheckout]);
-
-                                }}
-                                className={`px-3 py-2 rounded border text-sm ${selectedQuoteByOwner[ownerId]?.id === q.id
-                                  ? "bg-black text-white"
-                                  : "bg-white hover:bg-gray-50"
-                                  }`}
-                              >
-                                {q.carrier} {q.serviceLevel} • ${q.cost} • ETA {q.etaDays || "-"}d
-                              </button>
-                            );
-                          })}
-                        </div>
-
-                      </div>
-                    )}
                 </div>
               ))}
           </div>
@@ -787,26 +822,24 @@ export default function CheckoutPage() {
         <div className="p-4 space-y-2">
           <h2 className="text-lg font-semibold">Order Summary</h2>
           <div className="flex justify-between text-sm">
-            <span>Deposits (Refundable)</span>
-            <span>${checkouts[0]?.deposit?.toFixed(2) || "0.00"}</span>
+            <SummaryLabel label="Deposits (Refundable)" tooltip={depositSummaryTooltipText} />
+            <span>${displayDeposit.toFixed(2)}</span>
           </div>
           <div className="flex justify-between text-sm">
             <span>Purchase Price</span>
-            <span>${checkouts[0]?.bookFee?.toFixed(2) || "0.00"}</span>
+            <span>${displayPurchaseFee.toFixed(2)}</span>
           </div>
           <div className="flex justify-between text-sm">
-            <span>Shipping Fee</span>
-            <span>${checkouts[0]?.shippingFee?.toFixed(2) || "0.00"}</span>
+            <SummaryLabel label="Shipping Fee" tooltip={shippingSummaryTooltipText} />
+            <span>${displayShippingFee.toFixed(2)}</span>
           </div>
           <div className="flex justify-between text-sm text-amber-700">
-            <span>Estimated Income from Deposits</span>
-            <span>${Number(checkouts[0]?.ownerIncomeAmount ?? totalEstimatedIncome).toFixed(2)}</span>
+            <SummaryLabel label="Rental Fee" tooltip={rentalSummaryTooltipText} />
+            <span>${displayRentalFee.toFixed(2)}</span>
           </div>
-          <div className="mt-2 rounded-md border border-gray-200 bg-gray-50 px-3 py-2">
-            <div className="flex justify-between text-sm font-medium">
-              <span>Platform Fee (5% of all fees above)</span>
-              <span>${checkouts[0]?.serviceFee?.toFixed(2) || "0.00"}</span>
-            </div>
+          <div className="flex justify-between text-sm">
+            <SummaryLabel label="Service Fee" tooltip={serviceFeeTooltipText} />
+            <span>${displayServiceFee.toFixed(2)}</span>
           </div>
           {donationAmount && parseFloat(donationAmount) > 0 && (
             <div className="flex justify-between text-sm text-green-600 font-medium">
@@ -817,15 +850,9 @@ export default function CheckoutPage() {
           <div className="flex justify-between text-lg font-bold border-t pt-2">
             <span>Total {donationAmount && parseFloat(donationAmount) > 0 ? "to Pay" : "Due"}</span>
             <span>
-              ${((checkouts[0]?.totalDue || 0) + (parseFloat(donationAmount) || 0)).toFixed(2)}
+              ${(displayTotalDue + (parseFloat(donationAmount) || 0)).toFixed(2)}
             </span>
           </div>
-          <p className="text-xs text-gray-500">
-            Deposits may be refundable upon return. Shipping is charged per owner based on your selected quote.
-          </p>
-          <p className="text-xs text-amber-700">
-            Estimated income is included in the checkout total.
-          </p>
         </div>
       </Card>
 

--- a/frontendNext/app/lending/add/page.tsx
+++ b/frontendNext/app/lending/add/page.tsx
@@ -24,10 +24,8 @@ type FormState = Omit<Book, "id" | "ownerId" | "dateAdded" | "updateDate"> & {
 
 const depositTooltipText =
   "Deposit is refundable upon timely return of the book in good condition.";
-const estimatedIncomeTooltipText =
-  "This is the owner's optional extra income. It can be 0.";
-const depositIncomePercentages = [0, 5, 10, 15, 20];
-
+const rentalPerDayTooltipText =
+  "Set your daily rental rate, including $0/day for free borrowing. Your rental income is calculated from the borrower's rental days.";
 export default function AddBook() {
   const [form, setForm] = useState<FormState>({
     titleOr: "",
@@ -40,8 +38,8 @@ export default function AddBook() {
     tags: [],
     deposit: undefined,
     salePrice: undefined,
-    maxLendingDays: 14,
-    depositIncomePercentage: 5,
+    maxLendingDays: 30,
+    depositIncomePercentage: 0,
     condition: "like-new",
     conditionImgURLs: [],
     isbn: "",
@@ -67,9 +65,6 @@ export default function AddBook() {
 
   const [showErrors, setShowErrors] = useState(false);
   const router = useRouter();
-  const estimatedDepositIncome =
-    ((Number(form.deposit) || 0) * (Number(form.depositIncomePercentage) || 0)) / 100;
-
   const handleChange = (
   e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>
 ) => {
@@ -228,7 +223,7 @@ export default function AddBook() {
       isbn: form.isbn || undefined,
       publishYear: form.publishYear ? Number(form.publishYear) : undefined,
       tags: tagsInput.split(",").map((t) => t.trim()).filter(Boolean),
-      maxLendingDays: Number(form.maxLendingDays) || 14,
+      maxLendingDays: 30,
       depositIncomePercentage: Number(form.depositIncomePercentage ?? 0),
 
       deliveryMethod: form.deliveryMethod as Book["deliveryMethod"],
@@ -552,7 +547,7 @@ export default function AddBook() {
                   {/* canRent = true */}
                   {form.canRent && (
                     <div className="space-y-3">
-                      <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
+                      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
                       <Input
                         label={
                           <span className="flex items-center gap-1.5">
@@ -575,43 +570,41 @@ export default function AddBook() {
                         placeholder="AU$"
                         required={form.canRent}
                       />
-                      <Input
-                        label="Lend Duration*"
-                        name="maxLendingDays"
-                        value={form.maxLendingDays}
-                        onChange={handleChange}
-                        placeholder="Days"
-                        required={form.canRent}
-                      />
-                      <Select
-                        label="Income Percentage*"
-                        name="depositIncomePercentage"
-                        value={form.depositIncomePercentage}
-                        onChange={handleChange}
-                        required={form.canRent}
-                      >
-                        {depositIncomePercentages.map((percentage) => (
-                          <option key={percentage} value={percentage}>
-                            {percentage}%
-                          </option>
-                        ))}
-                      </Select>
-                      </div>
-                      <p className="text-sm text-amber-700 flex items-center gap-1.5">
-                        <span>
-                          Estimated Income: AU${estimatedDepositIncome.toFixed(2)} ({form.depositIncomePercentage}% of deposit fee)
-                        </span>
-                        <span className="group relative inline-flex items-center">
-                          <CircleHelp
-                            className="h-4 w-4 cursor-help text-gray-400"
-                            aria-label={estimatedIncomeTooltipText}
-                            title={estimatedIncomeTooltipText}
-                          />
-                          <span className="pointer-events-none absolute left-1/2 top-full z-10 mt-2 w-60 -translate-x-1/2 rounded-md bg-gray-900 px-3 py-2 text-xs font-normal leading-5 text-white opacity-0 shadow-lg transition-opacity duration-150 group-hover:opacity-100 group-focus-within:opacity-100">
-                            {estimatedIncomeTooltipText}
+                      <div>
+                        <label className="block text-sm font-medium text-gray-700 mb-2">
+                          <span className="flex items-center gap-1.5">
+                            <span>Rental/Day*</span>
+                            <span className="group relative inline-flex items-center">
+                              <CircleHelp
+                                className="h-4 w-4 cursor-help text-gray-400"
+                                aria-label={rentalPerDayTooltipText}
+                                title={rentalPerDayTooltipText}
+                              />
+                              <span className="pointer-events-none absolute left-1/2 top-full z-10 mt-2 w-72 -translate-x-1/2 rounded-md bg-gray-900 px-3 py-2 text-xs font-normal leading-5 text-white opacity-0 shadow-lg transition-opacity duration-150 group-hover:opacity-100 group-focus-within:opacity-100">
+                                {rentalPerDayTooltipText}
+                              </span>
+                            </span>
                           </span>
-                        </span>
-                      </p>
+                        </label>
+                        <input
+                          type="range"
+                          name="depositIncomePercentage"
+                          min="0"
+                          max="20"
+                          step="1"
+                          value={Number(form.depositIncomePercentage ?? 0)}
+                          onChange={handleChange}
+                          className="w-full accent-black"
+                        />
+                        <div className="mt-2 flex items-center justify-between text-sm text-gray-600">
+                          <span>$0.0/day</span>
+                          <span className="font-medium text-gray-900">
+                            ${(Number(form.depositIncomePercentage ?? 0) / 10).toFixed(1)}/day
+                          </span>
+                          <span>$2.0/day</span>
+                        </div>
+                      </div>
+                      </div>
                     </div>
                   )}
                 </div>

--- a/frontendNext/app/lending/edit/[id]/page.tsx
+++ b/frontendNext/app/lending/edit/[id]/page.tsx
@@ -23,10 +23,8 @@ type FormState = Omit<Book, "id" | "ownerId" | "dateAdded" | "updateDate"> & {
 
 const depositTooltipText =
   "Deposit is refundable upon timely return of the book in good condition.";
-const estimatedIncomeTooltipText =
-  "This is the owner's optional extra income. It can be 0.";
-const depositIncomePercentages = [0, 5, 10, 15, 20];
-
+const rentalPerDayTooltipText =
+  "Set your daily rental rate, including $0/day for free borrowing. Your rental income is calculated from the borrower's rental days.";
 export default function EditBookPage() {
   const { id: bookId } = useParams<{ id: string }>();
   const router = useRouter();
@@ -61,7 +59,7 @@ export default function EditBookPage() {
         isbn: b.isbn ?? "",
         tags: b.tags ?? [],
         publishYear: b.publishYear,
-        maxLendingDays: b.maxLendingDays,
+        maxLendingDays: b.maxLendingDays || 30,
         depositIncomePercentage: b.depositIncomePercentage ?? 0,
         deliveryMethod: b.deliveryMethod,
         salePrice: b.salePrice,
@@ -94,9 +92,6 @@ export default function EditBookPage() {
       return { ...prev, [name]: type === "checkbox" ? checked : value };
     });
   };
-  const estimatedDepositIncome =
-    ((Number(form.deposit) || 0) * (Number(form.depositIncomePercentage) || 0)) / 100;
-
   // upload cover
   const handleCoverFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -182,7 +177,7 @@ export default function EditBookPage() {
       isbn: form.isbn || undefined,
       tags: tagsInput.split(",").map((t) => t.trim()).filter(Boolean),
       publishYear: form.publishYear,
-      maxLendingDays: form.maxLendingDays,
+      maxLendingDays: 30,
       depositIncomePercentage: Number(form.depositIncomePercentage ?? 0),
       deliveryMethod: form.deliveryMethod,
       salePrice: form.salePrice,
@@ -507,43 +502,41 @@ export default function EditBookPage() {
                         placeholder="AU$"
                         required={form.canRent}
                       />
-                      <Input
-                        label="Lend Duration*"
-                        name="maxLendingDays"
-                        value={form.maxLendingDays}
-                        onChange={handleChange}
-                        placeholder="Days"
-                        required={form.canRent}
-                      />
-                      <Select
-                        label="Income Percentage*"
-                        name="depositIncomePercentage"
-                        value={form.depositIncomePercentage}
-                        onChange={handleChange}
-                        required={form.canRent}
-                      >
-                        {depositIncomePercentages.map((percentage) => (
-                          <option key={percentage} value={percentage}>
-                            {percentage}%
-                          </option>
-                        ))}
-                      </Select>
-                      </div>
-                      <p className="text-sm text-amber-700 flex items-center gap-1.5">
-                        <span>
-                          Estimated Income: AU${estimatedDepositIncome.toFixed(2)} ({form.depositIncomePercentage}% of deposit fee)
-                        </span>
-                        <span className="group relative inline-flex items-center">
-                          <CircleHelp
-                            className="h-4 w-4 cursor-help text-gray-400"
-                            aria-label={estimatedIncomeTooltipText}
-                            title={estimatedIncomeTooltipText}
-                          />
-                          <span className="pointer-events-none absolute left-1/2 top-full z-10 mt-2 w-60 -translate-x-1/2 rounded-md bg-gray-900 px-3 py-2 text-xs font-normal leading-5 text-white opacity-0 shadow-lg transition-opacity duration-150 group-hover:opacity-100 group-focus-within:opacity-100">
-                            {estimatedIncomeTooltipText}
+                      <div>
+                        <label className="block text-sm font-medium text-gray-700 mb-2">
+                          <span className="flex items-center gap-1.5">
+                            <span>Rental/Day*</span>
+                            <span className="group relative inline-flex items-center">
+                              <CircleHelp
+                                className="h-4 w-4 cursor-help text-gray-400"
+                                aria-label={rentalPerDayTooltipText}
+                                title={rentalPerDayTooltipText}
+                              />
+                              <span className="pointer-events-none absolute left-1/2 top-full z-10 mt-2 w-72 -translate-x-1/2 rounded-md bg-gray-900 px-3 py-2 text-xs font-normal leading-5 text-white opacity-0 shadow-lg transition-opacity duration-150 group-hover:opacity-100 group-focus-within:opacity-100">
+                                {rentalPerDayTooltipText}
+                              </span>
+                            </span>
                           </span>
-                        </span>
-                      </p>
+                        </label>
+                        <input
+                          type="range"
+                          name="depositIncomePercentage"
+                          min="0"
+                          max="20"
+                          step="1"
+                          value={Number(form.depositIncomePercentage ?? 0)}
+                          onChange={handleChange}
+                          className="w-full accent-black"
+                        />
+                        <div className="mt-2 flex items-center justify-between text-sm text-gray-600">
+                          <span>$0.0/day</span>
+                          <span className="font-medium text-gray-900">
+                            ${(Number(form.depositIncomePercentage ?? 0) / 10).toFixed(1)}/day
+                          </span>
+                          <span>$2.0/day</span>
+                        </div>
+                      </div>
+                      </div>
                     </div>
                   )}
                 </div>

--- a/frontendNext/app/lending/page.tsx
+++ b/frontendNext/app/lending/page.tsx
@@ -290,10 +290,26 @@ export default function LendingListPage() {
         throw new Error("Failed to confirm shipment");
       }
 
+      setOrderMap((prev) => ({
+        ...prev,
+        [selectedOrderId]: prev[selectedOrderId]
+          ? {
+              ...prev[selectedOrderId],
+              shippingOutTrackingNumber: trackingNumber.trim(),
+            }
+          : prev[selectedOrderId],
+      }));
+
       const updatedOrder = await getOrderById(selectedOrderId);
       setOrderMap((prev) => ({
         ...prev,
-        [selectedOrderId]: updatedOrder,
+        [selectedOrderId]: {
+          ...updatedOrder,
+          shippingOutTrackingNumber:
+            updatedOrder?.shippingOutTrackingNumber ||
+            prev[selectedOrderId]?.shippingOutTrackingNumber ||
+            null,
+        },
       }));
       setShipModalOpen(false);
       toast.success("Shipment confirmed successfully");
@@ -514,7 +530,7 @@ export default function LendingListPage() {
                               {hasBorrowerReceived
                                 ? "Shipped"
                                 : currentOrder?.shippingOutTrackingNumber
-                                  ? "Update Shipment"
+                                  ? "Update Shipping"
                                   : "Ship"}
                             </Button>
                           )}

--- a/frontendNext/app/message/page.tsx
+++ b/frontendNext/app/message/page.tsx
@@ -17,6 +17,7 @@ import {
   sendMessageWithImage,
   getUserByEmail,
 } from "@/utils/messageApi";
+import { formatLocalDateTime } from "@/utils/datetime";
 
 const API_URL = getApiUrl();
 const WS_URL = process.env.NEXT_PUBLIC_WS_URL || "ws://localhost:8000";
@@ -883,11 +884,7 @@ export default function MessagesPage() {
                         </p>
                         <p>
                           <span className="font-medium text-gray-900">Time:</span>{" "}
-                          {selectedNotification.created_at
-                            ? new Date(selectedNotification.created_at).toLocaleString("en-AU", {
-                                timeZone: "Australia/Perth",
-                              })
-                            : "N/A"}
+                          {formatLocalDateTime(selectedNotification.created_at, "N/A")}
                         </p>
                       </div>
                     </div>

--- a/frontendNext/app/refunds/[id]/page.tsx
+++ b/frontendNext/app/refunds/[id]/page.tsx
@@ -7,6 +7,7 @@ import Card from "../../components/ui/Card";
 import Button from "../../components/ui/Button";
 import { getRefundsForOrder } from "@/utils/payments";
 import { getCurrentUser } from "@/utils/auth";
+import { formatLocalDateTime } from "@/utils/datetime";
 
 interface RefundRecord {
   refund_id: string;
@@ -98,14 +99,7 @@ export default function RefundDetailPage() {
     loadData();
   }, [orderId]);
 
-  const fmtDate = (v?: string | null) => {
-    if (!v) return "-";
-    try {
-      return new Date(v).toLocaleString();
-    } catch {
-      return "Invalid date";
-    }
-  };
+  const fmtDate = (v?: string | null) => formatLocalDateTime(v, "-");
 
   const fmtAmount = (amount: number, currency: string) => {
     const dollars = (amount / 100).toFixed(2);
@@ -328,7 +322,7 @@ export default function RefundDetailPage() {
                       </div>
                       {(order.ownerIncomeAmount || 0) > 0 && (
                         <div className="flex justify-between text-gray-500 pl-3">
-                          <span>Owner Income</span>
+                          <span>Rental Fee</span>
                           <span>{fmtDollars(order.ownerIncomeAmount || 0)}</span>
                         </div>
                       )}

--- a/frontendNext/app/refunds/page.tsx
+++ b/frontendNext/app/refunds/page.tsx
@@ -7,6 +7,7 @@ import Card from "../components/ui/Card";
 import Button from "../components/ui/Button";
 import { getUserRefunds } from "@/utils/payments";
 import { getCurrentUser } from "@/utils/auth";
+import { formatLocalDateTime } from "@/utils/datetime";
 
 type RefundStatus = "succeeded" | "pending" | "failed";
 
@@ -108,14 +109,7 @@ export default function RefundsPage() {
     { value: "failed", label: "Failed", count: countByStatus("failed") },
   ] as const;
 
-  const fmtDate = (v?: string | null) => {
-    if (!v) return "-";
-    try {
-      return new Date(v).toLocaleString();
-    } catch {
-      return "Invalid date";
-    }
-  };
+  const fmtDate = (v?: string | null) => formatLocalDateTime(v, "-");
 
   const fmtAmount = (cents: number, currency: string) => {
     const dollars = (cents / 100).toFixed(2);

--- a/frontendNext/app/store/cartStore.ts
+++ b/frontendNext/app/store/cartStore.ts
@@ -60,6 +60,19 @@ export const useCartStore = create<CartState>((set, get) => ({
   // 添加到购物车
   addToCart: async (book, preferredMode) => {
     const { cart } = get();
+    let currentUser: { id?: string } | null = null;
+    if (typeof window !== "undefined") {
+      try {
+        const currentUserRaw = localStorage.getItem("user");
+        currentUser = currentUserRaw ? JSON.parse(currentUserRaw) : null;
+      } catch {
+        currentUser = null;
+      }
+    }
+
+    if (currentUser?.id && currentUser.id === book.ownerId) {
+      return false;
+    }
 
     // ✅ 已存在，返回 "duplicate"
     if (cart.some((b) => b.bookId === book.id)) {

--- a/frontendNext/app/types/book.ts
+++ b/frontendNext/app/types/book.ts
@@ -43,7 +43,7 @@ export interface Book {
   tags: string[];
   publishYear?: number;
   maxLendingDays: number;
-  depositIncomePercentage?: number;
+  depositIncomePercentage?: number; // stored as rental/day for borrow listings
 
   // 配送
   deliveryMethod: "post" | "pickup" | "both";

--- a/frontendNext/utils/checkout.ts
+++ b/frontendNext/utils/checkout.ts
@@ -70,7 +70,8 @@ export async function rebuildCheckout(
   user: User,
   items: any[],
   shipping: Record<string, "post" | "pickup"> = {},
-  selectedQuotes: Record<string, any> = {}
+  selectedQuotes: Record<string, any> = {},
+  rentalDays: Record<string, number> = {}
 ) {
   // 1. get current checkout id
   const existing = await getMyCheckouts();
@@ -104,8 +105,12 @@ export async function rebuildCheckout(
         bookId,
         ownerId: it.ownerId,
         actionType: (it.mode || it.actionType)?.toUpperCase(), // default BORROW
-        price: mode === "purchase" ? (it.salePrice || it.price) : undefined, // Sale Price
+        price:
+          mode === "purchase"
+            ? (it.salePrice || it.price)
+            : (it.rentalPerDay || it.depositIncomePercentage || 0) * (rentalDays[bookId] || it.rentalDays || 1),
         deposit: mode === "borrow" ? it.deposit : undefined,
+        rentalDays: mode === "borrow" ? (rentalDays[bookId] || it.rentalDays || 1) : undefined,
         shippingMethod:
           shipping[bookId] ||
           it.shippingMethod ||

--- a/frontendNext/utils/datetime.ts
+++ b/frontendNext/utils/datetime.ts
@@ -1,0 +1,9 @@
+export function formatLocalDateTime(value?: string | null, fallback = "—") {
+  if (!value) return fallback;
+  const dt = new Date(value);
+  if (Number.isNaN(dt.getTime())) return fallback;
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(dt);
+}


### PR DESCRIPTION
## Summary

This PR updates the lending, checkout, borrowing, message, and refunds flows to align rental pricing, shipping interactions, and time display behavior across the app.

## What changed

- Removed old lending inputs for duration and income percentage
- Replaced `Rental/Day` with a slider that supports `0.0` to `2.0` per day
- Added a shorter product-style tooltip for `Rental/Day`, including support for `$0/day`
- Updated book detail pricing layout for `Rental/Day`
- Renamed rental-related labels from income-based wording to rental-based wording
- Added automatic rental fee calculation in checkout: `rental/day × rental days`
- Changed service fee to a fixed `$2` per transaction
- Separated rental details from delivery details in checkout
- Made shipping fees calculate automatically after delivery method selection
- Merged delivery method and shipping quotes into one delivery section
- Improved shipping action labels so shipped orders show `Update Shipping`
- Prevented users from requesting their own listed books
- Fixed stale shipping button state after confirming shipment
- Unified backend datetime serialization to UTC ISO format
- Unified frontend local datetime formatting for borrowing, message, and refunds pages
- Fixed incorrect timestamps in borrowing, system messages, and refunds flows

## Notes

- Shipping and rental UI now update more predictably after user actions
- Date/time handling is now more consistent across pages
- Refactors were kept small and focused to avoid unnecessary duplication while preserving existing behavior

## Testing

- Verified relevant backend files with `python3 -m py_compile`
- Frontend build was not fully run in the current environment because the local `next/tsc` executable was unavailable
