### PR TITLE
test: MVP6 + MVP6-1 coverage (61 new tests, 1 prod fix, drift cleanup)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,3 +165,13 @@ fastapi/media/*/deposit_evidence/
 # Local-only docs/notes
 docs/architecture-diagram.html
 如何测试 测试 账户 普通 管理员Admin.txt
+
+# Personal D2 deliverables and drafts (per-author, not team artefacts)
+docs/D2-*
+docs/Yuxing*D2*
+docs/build_d2_report.js
+docs/*-proposal.md
+docs/The complete flow*.png
+
+# User-uploaded message attachments and evidence — additional pattern
+fastapi/media/U*/

--- a/fastapi/services/deposit_service.py
+++ b/fastapi/services/deposit_service.py
@@ -92,6 +92,10 @@ def _persist_refund_record(db: Session, payment_id: str, stripe_refund: Dict[str
         status=stripe_refund["status"],
         reason=reason,
     ))
+    # Flush the just-added Refund so the SUM(Refund.amount) below sees it.
+    # SessionLocal is configured autoflush=False, so without this a full-amount
+    # refund would be miscategorized as 'partially_refunded'.
+    db.flush()
 
     payment = db.query(Payment).filter(Payment.payment_id == payment_id).first()
     if payment:

--- a/fastapi/services/order_service.py
+++ b/fastapi/services/order_service.py
@@ -122,29 +122,30 @@ class OrderService:
             - shipping_out_fee_amount
             - order_total
 
-        Return examples:
+        Return examples (post-PR-#88: fixed $2 service fee charged ONCE on
+        the first order in a multi-order checkout, $0 on the rest):
             [
                 {
-                    "items": [CheckoutItem(ci1), CheckoutItem(ci2)],  # borrow, owner1
+                    "items": [CheckoutItem(ci1), CheckoutItem(ci2)],  # borrow, owner1 (first)
                     "deposit_or_sale_amount": 25.0,                   # 10 + 15
                     "owner_income_amount": 2.5,
-                    "service_fee_amount": 5.0,                        # checkout.service_fee
+                    "service_fee_amount": 2.0,                        # PLATFORM_SERVICE_FEE_AMOUNT
                     "shipping_out_fee_amount": 3.0,                   # first post shipping_quote
-                    "order_total": 35.5                               # 25 + 2.5 + 5 + 3
+                    "order_total": 32.5                               # 25 + 2.5 + 2 + 3
                 },
                 {
                     "items": [CheckoutItem(ci3)],                     # purchase, owner1
                     "deposit_or_sale_amount": 20.0,                   # purchase price
-                    "service_fee_amount": 5.0,
+                    "service_fee_amount": 0.0,                        # 0 — fee already charged on first order
                     "shipping_out_fee_amount": 0.0,                   # pickup, no shipping
-                    "order_total": 25.0                                # 20 + 5 + 0
+                    "order_total": 20.0                                # 20 + 0 + 0
                 },
                 {
                     "items": [CheckoutItem(ci4)],                     # purchase, owner2
                     "deposit_or_sale_amount": 25.0,                   # purchase price
-                    "service_fee_amount": 5.0,
+                    "service_fee_amount": 0.0,                        # 0 — fee already charged on first order
                     "shipping_out_fee_amount": 4.0,                   # post shipping
-                    "order_total": 34.0                                # 25 + 5 + 4
+                    "order_total": 29.0                                # 25 + 0 + 4
                 }
             ]
         """
@@ -175,7 +176,9 @@ class OrderService:
                 # if pickup, shipping_out_fee_amount = 0
                 shipping_out_fee_amount = float(post_items[0].shipping_quote or 0)
 
-            # Platform service fee = (item total incl. shipping) * 5%
+            # Platform service fee = fixed $2 (PLATFORM_SERVICE_FEE_AMOUNT),
+            # charged ONCE per checkout — only on the first order, not on
+            # subsequent orders in a multi-owner checkout.
             service_fee_base = deposit_or_sale_amount + owner_income_amount + shipping_out_fee_amount
             service_fee_amount = OrderService._calculate_service_fee(service_fee_base) if index == 0 else 0.0
 

--- a/fastapi/tests/conftest.py
+++ b/fastapi/tests/conftest.py
@@ -1,0 +1,557 @@
+"""
+Pytest fixtures for FastAPI backend tests.
+
+Strategy:
+- sqlite in-memory engine with StaticPool so the in-memory DB persists across
+  connections within a single process.
+- Per-test transactional isolation: each test gets a fresh session bound to a
+  rolled-back transaction, so tests cannot leak state into each other.
+- Tables are created lazily — fixtures only require the tables they touch.
+  Models that use MySQL-specific types (e.g. JSON) are NOT imported globally;
+  integration-level fixtures opt them in explicitly.
+"""
+
+import os
+import sys
+import uuid
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+
+# Ensure `fastapi/` is importable as the package root for `from models...`,
+# `from services...`, etc., regardless of where pytest is invoked from.
+_FASTAPI_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if _FASTAPI_ROOT not in sys.path:
+    sys.path.insert(0, _FASTAPI_ROOT)
+
+
+# ---------------------------------------------------------------------------
+# Engine / Session factory (session-scoped — built once per pytest run)
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="session")
+def engine():
+    """Single in-memory sqlite engine shared across the test session."""
+    eng = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    yield eng
+    eng.dispose()
+
+
+@pytest.fixture(scope="session")
+def TestingSessionLocal(engine):
+    return sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+# ---------------------------------------------------------------------------
+# Schema fixtures — opt in only the tables you need.
+# ---------------------------------------------------------------------------
+
+def _import_all_models():
+    """
+    Import every models module so SQLAlchemy can resolve string-based
+    relationships during mapper configuration (e.g. OrderBook -> 'Book').
+
+    Importing a module only registers the mapper class; it does NOT create
+    the table. This lets us include models whose columns use MySQL-specific
+    types (e.g. dialects.mysql.JSON in book/complaint/deposit_evidence)
+    without forcing those tables onto sqlite.
+    """
+    from models import (  # noqa: F401  (imports for side effects only)
+        admin_setting,
+        ban,
+        blacklist,
+        book,
+        cart,
+        checkout,
+        complaint,
+        deposit_audit_log,
+        deposit_evidence,
+        mail,
+        message,
+        order,
+        payment_gateway,
+        payment_split,
+        review,
+        service_fee,
+        system_notification,
+        user,
+    )
+
+
+@pytest.fixture(scope="session")
+def deposit_strike_schema(engine):
+    """
+    Minimal schema for deposit-strike unit tests:
+      - users
+      - system_notifications
+    All other model classes are imported (so SQLAlchemy can resolve
+    relationships) but their tables are not created.
+    """
+    _import_all_models()
+    from models.user import User
+    from models.system_notification import SystemNotification
+
+    User.__table__.create(bind=engine, checkfirst=True)
+    SystemNotification.__table__.create(bind=engine, checkfirst=True)
+    yield
+    # Don't drop — engine teardown handles it. Dropping here would force every
+    # subsequent fixture to recreate tables unnecessarily.
+
+
+@pytest.fixture(scope="session")
+def deposit_arbitration_schema(deposit_strike_schema, engine):
+    """
+    Extended schema for deposit_service admin_release/deduct/forfeit tests.
+
+    Adds (in addition to deposit_strike_schema):
+      - orders, payments, refunds, deposit_audit_log
+
+    Note: order_books / disputes tables are intentionally NOT created — the
+    arbitration code path doesn't insert into them. Skipping them lets us
+    avoid pulling in the Book model's mysql.JSON columns.
+    """
+    from models.order import Order
+    from models.payment_gateway import Payment, Refund
+    from models.deposit_audit_log import DepositAuditLog
+
+    Payment.__table__.create(bind=engine, checkfirst=True)
+    Order.__table__.create(bind=engine, checkfirst=True)
+    Refund.__table__.create(bind=engine, checkfirst=True)
+    DepositAuditLog.__table__.create(bind=engine, checkfirst=True)
+    yield
+
+
+# ---------------------------------------------------------------------------
+# Per-test session with transaction rollback isolation
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def db(engine, TestingSessionLocal):
+    """
+    Per-test SQLAlchemy session with transactional isolation.
+
+    Each test runs inside an outer transaction that is rolled back at teardown,
+    so commits inside the code under test are confined to this transaction and
+    do not bleed into other tests.
+
+    NOTE: `db.commit()` inside service code will commit the inner SAVEPOINT,
+    not the outer transaction. The session is configured with
+    `join_transaction_mode="create_savepoint"` (SQLAlchemy 2.0+) to support this.
+
+    SCHEMA WARNING: This fixture creates NO tables on its own. Tests that
+    query/insert into models must additionally depend on a schema fixture
+    (e.g. `deposit_strike_schema`) — either directly, or transitively via a
+    user fixture (`borrower` / `admin` / `make_user`) that already declares
+    the schema dependency.
+
+    Example::
+
+        def test_something(db, deposit_strike_schema):  # explicit
+            ...
+
+        def test_something_else(borrower):              # transitive (preferred)
+            # `borrower` depends on `db` and `deposit_strike_schema`
+            ...
+    """
+    connection = engine.connect()
+    transaction = connection.begin()
+    session = TestingSessionLocal(
+        bind=connection,
+        join_transaction_mode="create_savepoint",
+    )
+    try:
+        yield session
+    finally:
+        session.close()
+        transaction.rollback()
+        connection.close()
+
+
+# ---------------------------------------------------------------------------
+# Convenience user fixtures — assume `deposit_strike_schema` is in scope.
+# ---------------------------------------------------------------------------
+
+def _make_user(db, **overrides):
+    """Create a User with sensible test defaults; override any field via kwargs."""
+    from models.user import User
+
+    defaults = dict(
+        user_id=overrides.pop("user_id", f"user-{uuid.uuid4().hex[:8]}"),
+        email=overrides.pop("email", f"u{uuid.uuid4().hex[:6]}@test.com"),
+        password_hash="not-a-real-hash",
+        name="Test User",
+        is_admin=False,
+        damage_strike_count=0,
+        damage_severity_score=0,
+        is_restricted=False,
+    )
+    defaults.update(overrides)
+    user = User(**defaults)
+    db.add(user)
+    db.flush()
+    return user
+
+
+@pytest.fixture
+def borrower(deposit_strike_schema, db):
+    """Clean borrower with zero strikes / score, not restricted.
+
+    Schema fixture is listed first to signal that the `users` table must
+    exist before `db` is used to insert.
+    """
+    return _make_user(db, name="Bob Borrower")
+
+
+@pytest.fixture
+def admin(deposit_strike_schema, db):
+    return _make_user(db, name="Admin", is_admin=True)
+
+
+@pytest.fixture
+def make_user(deposit_strike_schema, db):
+    """Factory for tests that need multiple users with custom strike state."""
+    def _factory(**overrides):
+        return _make_user(db, **overrides)
+    return _factory
+
+
+# ---------------------------------------------------------------------------
+# Phase 4: Arbitration fixtures (orders, payments, Stripe mock)
+# ---------------------------------------------------------------------------
+
+def _make_payment(db, **overrides):
+    """Create a Payment with sensible defaults (deposit-only)."""
+    from models.payment_gateway import Payment
+
+    pid = overrides.pop("payment_id", f"pi_test_{uuid.uuid4().hex[:10]}")
+    defaults = dict(
+        payment_id=pid,
+        checkout_id=overrides.pop("checkout_id", f"cs_test_{uuid.uuid4().hex[:10]}"),
+        user_id="borrower-x",
+        amount=2000,            # cents
+        currency="aud",
+        status="succeeded",
+        deposit=2000,           # cents — what _deposit_cents returns
+        purchase=0,
+        shipping_fee=0,
+        service_fee=0,
+        action_type="BORROW",
+        destination="destination",
+    )
+    defaults.update(overrides)
+    p = Payment(**defaults)
+    db.add(p)
+    db.flush()
+    return p
+
+
+def _make_order(db, *, owner, borrower, payment=None, **overrides):
+    """Create an Order with deposit_status='pending_review' by default."""
+    from models.order import Order
+
+    defaults = dict(
+        owner_id=owner.user_id,
+        borrower_id=borrower.user_id,
+        status="BORROWING",
+        action_type="borrow",
+        shipping_method="post",
+        deposit_or_sale_amount=20.00,   # dollars — fallback if payment is None
+        owner_income_amount=0.00,
+        service_fee_amount=0.00,
+        total_paid_amount=20.00,
+        deposit_status="pending_review",
+        deposit_deducted_cents=0,
+        contact_name="Bob Borrower",
+        street="1 Test St",
+        city="Perth",
+        postcode="6000",
+        country="Australia",
+        payment_id=payment.payment_id if payment else None,
+    )
+    defaults.update(overrides)
+    o = Order(**defaults)
+    db.add(o)
+    db.flush()
+    return o
+
+
+@pytest.fixture
+def make_order(deposit_arbitration_schema, db):
+    """
+    Factory: create an Order in pending_review.
+
+    By default the order has a paid Payment row linked. Pass `with_payment=False`
+    to create an Order with `payment_id=None` — used to test code paths that
+    skip Stripe when there's no payment to refund against.
+
+    Usage:
+        order = make_order(borrower=b, owner=o)                    # paid
+        order = make_order(borrower=b, owner=o, deposit_cents=5000) # paid, custom amount
+        order = make_order(borrower=b, owner=o, with_payment=False) # no payment
+    """
+    def _factory(*, owner, borrower, deposit_cents=2000, with_payment=True,
+                 **order_overrides):
+        payment = None
+        if with_payment:
+            payment = _make_payment(db, deposit=deposit_cents, amount=deposit_cents,
+                                    user_id=borrower.user_id)
+        return _make_order(db, owner=owner, borrower=borrower, payment=payment,
+                           **order_overrides)
+    return _factory
+
+
+@pytest.fixture(scope="session")
+def admin_refund_schema(deposit_arbitration_schema, engine):
+    """
+    Schema for MVP6 Phase 3 admin refund endpoint tests (Phase 6).
+
+    Adds (in addition to deposit_arbitration_schema):
+      - payment_splits — needed by manual refund / list / detail endpoints
+      - audit_logs     — written by retry & manual endpoints
+    """
+    from models.payment_split import PaymentSplit
+    from models.payment_gateway import AuditLog
+
+    PaymentSplit.__table__.create(bind=engine, checkfirst=True)
+    AuditLog.__table__.create(bind=engine, checkfirst=True)
+    yield
+
+
+@pytest.fixture(scope="session")
+def restriction_guard_schema(deposit_strike_schema, engine):
+    """
+    Schema for create_order is_restricted guard tests (Phase 5).
+
+    Adds checkout + checkout_item tables. These models live on a SEPARATE
+    declarative_base in `models/checkout.py`, so they aren't picked up by
+    `models.base.Base.metadata`. We create them table-by-table.
+    """
+    from models.checkout import Checkout, CheckoutItem
+
+    Checkout.__table__.create(bind=engine, checkfirst=True)
+    CheckoutItem.__table__.create(bind=engine, checkfirst=True)
+    yield
+
+
+def _make_checkout(db, user, **overrides):
+    """Create a Checkout row for `user`."""
+    from models.checkout import Checkout
+
+    defaults = dict(
+        checkout_id=overrides.pop("checkout_id", f"co-{uuid.uuid4().hex[:8]}"),
+        user_id=user.user_id,
+        contact_name="Bob Borrower",
+        phone="0400-000-000",
+        street="1 Test St",
+        city="Perth",
+        postcode="6000",
+        country="Australia",
+        status="PENDING",
+    )
+    defaults.update(overrides)
+    co = Checkout(**defaults)
+    db.add(co)
+    db.flush()
+    return co
+
+
+def _make_checkout_item(db, checkout, *, action_type="BORROW", **overrides):
+    """Create one CheckoutItem on a checkout."""
+    from models.checkout import CheckoutItem
+
+    defaults = dict(
+        item_id=overrides.pop("item_id", f"ci-{uuid.uuid4().hex[:8]}"),
+        checkout_id=checkout.checkout_id,
+        book_id=overrides.pop("book_id", f"book-{uuid.uuid4().hex[:8]}"),
+        owner_id=overrides.pop("owner_id", "owner-x"),
+        action_type=action_type,
+    )
+    defaults.update(overrides)
+    item = CheckoutItem(**defaults)
+    db.add(item)
+    db.flush()
+    return item
+
+
+@pytest.fixture
+def make_checkout(restriction_guard_schema, db):
+    """
+    Factory: create a Checkout with N items.
+
+    Usage:
+        co = make_checkout(user=user, items=[("BORROW",), ("PURCHASE",)])
+        co = make_checkout(user=user, items=[("borrow",)])    # lowercase ok
+    """
+    def _factory(*, user, items=(("BORROW",),), **checkout_overrides):
+        co = _make_checkout(db, user, **checkout_overrides)
+        for spec in items:
+            action_type = spec[0] if spec else "BORROW"
+            _make_checkout_item(db, co, action_type=action_type)
+        return co
+    return _factory
+
+
+# ---------------------------------------------------------------------------
+# FastAPI TestClient + dependency overrides (Phase 5+)
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def client(db):
+    """
+    A FastAPI TestClient with `get_db` overridden to use the per-test session.
+
+    `get_current_user` is NOT overridden by default — endpoints that require
+    auth will 401 until the test calls the `auth_as` helper.
+
+    Lifespan is NOT executed (TestClient with no `with` context skips it),
+    so production startup hooks like seed_sample_data and the scheduler
+    don't fire during tests.
+    """
+    from main import app
+    from core.dependencies import get_db
+    from fastapi.testclient import TestClient
+
+    def _override_get_db():
+        yield db
+
+    app.dependency_overrides[get_db] = _override_get_db
+    try:
+        yield TestClient(app)
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def auth_as():
+    """
+    Helper to install/override the `get_current_user` dependency.
+
+    Usage:
+        def test_x(client, auth_as, some_user):
+            auth_as(some_user)
+            res = client.post(...)
+    """
+    from main import app
+    from core.dependencies import get_current_user
+
+    def _set(user):
+        app.dependency_overrides[get_current_user] = lambda: user
+    return _set
+
+
+# ---------------------------------------------------------------------------
+# Phase 6: Admin refund endpoint helpers
+# ---------------------------------------------------------------------------
+
+def _make_payment_split(db, *, order_id, payment_id, **overrides):
+    from models.payment_split import PaymentSplit
+    from models.payment_gateway import Payment
+
+    defaults = dict(
+        order_id=order_id,
+        payment_id=payment_id,
+        owner_id=overrides.pop("owner_id", "owner-x"),
+        connected_account_id=overrides.pop("connected_account_id", "acct_test"),
+        currency="aud",
+        deposit_cents=2000,
+        shipping_cents=500,
+        service_fee_cents=0,
+        transfer_amount_cents=0,
+    )
+    defaults.update(overrides)
+    sp = PaymentSplit(**defaults)
+    db.add(sp)
+
+    # Sync the linked Payment.amount to the split totals. Production semantics:
+    # Payment.amount = full Stripe charge = deposit + shipping + service_fee.
+    # If we leave Payment.amount untouched (2000 cents from `_make_payment`)
+    # while the split says 2000+500=2500, the refund-cap check inside
+    # /refunds/admin/manual will reject any "full" refund as "would exceed
+    # original payment amount" — which is a fixture bug, not a test target.
+    payment = db.query(Payment).filter(Payment.payment_id == payment_id).first()
+    if payment:
+        payment.amount = (
+            int(sp.deposit_cents or 0)
+            + int(sp.shipping_cents or 0)
+            + int(sp.service_fee_cents or 0)
+        )
+
+    db.flush()
+    return sp
+
+
+def _make_refund(db, *, payment_id, status="succeeded", amount=2000, **overrides):
+    from models.payment_gateway import Refund
+    defaults = dict(
+        refund_id=overrides.pop("refund_id", f"re_test_{uuid.uuid4().hex[:10]}"),
+        payment_id=payment_id,
+        amount=amount,
+        currency="aud",
+        status=status,
+        reason=overrides.pop("reason", "Test refund"),
+    )
+    defaults.update(overrides)
+    r = Refund(**defaults)
+    db.add(r)
+    db.flush()
+    return r
+
+
+@pytest.fixture
+def make_payment_split(admin_refund_schema, db):
+    """Factory: create a PaymentSplit row for a given (order_id, payment_id)."""
+    def _factory(*, order_id, payment_id, **overrides):
+        return _make_payment_split(db, order_id=order_id, payment_id=payment_id, **overrides)
+    return _factory
+
+
+@pytest.fixture
+def make_refund(admin_refund_schema, db):
+    """Factory: create a Refund row directly (for retry/list tests)."""
+    def _factory(*, payment_id, status="succeeded", amount=2000, **overrides):
+        return _make_refund(db, payment_id=payment_id, status=status, amount=amount, **overrides)
+    return _factory
+
+
+@pytest.fixture
+def stripe_refund_recorder(monkeypatch):
+    """
+    Patch `stripe.Refund.create` to a recording fake.
+
+    Returns a list that gets one entry per call:
+        [{"payment_intent": "pi_...", "amount": 1500, "currency": "aud",
+          "id": "re_test_1", "status": "succeeded"}, ...]
+
+    The fake always succeeds with a deterministic refund id so tests can
+    assert on call shape without coupling to Stripe error handling. For
+    failure-path coverage, override `stripe.Refund.create` again inside
+    the test with `monkeypatch.setattr(...)`.
+    """
+    from types import SimpleNamespace
+    import stripe
+
+    calls = []
+
+    def _fake_create(payment_intent, amount, **kwargs):
+        # Use uuid to make refund_id globally unique — defensive against any
+        # test data that survives rollback (sqlite + savepoints can be quirky)
+        # and against the same fixture being reused across nested calls.
+        record = {
+            "payment_intent": payment_intent,
+            "amount": amount,
+            "id": f"re_test_{uuid.uuid4().hex[:10]}",
+            "currency": "aud",
+            "status": "succeeded",
+            **kwargs,
+        }
+        calls.append(record)
+        return SimpleNamespace(**record)
+
+    monkeypatch.setattr(stripe.Refund, "create", _fake_create)
+    return calls

--- a/fastapi/tests/test_admin_refund_endpoints.py
+++ b/fastapi/tests/test_admin_refund_endpoints.py
@@ -1,0 +1,371 @@
+"""
+Tests for MVP6 Phase 3 admin refund endpoints (routes/payment_gateway.py):
+
+  - GET  /api/v1/payment_gateway/refunds/admin               (list with KPI/pagination)
+  - POST /api/v1/payment_gateway/refunds/admin/{rid}/retry   (retry failed refund)
+  - POST /api/v1/payment_gateway/refunds/admin/manual        (admin-issued refund)
+
+Goals:
+  - Verify the admin auth gate fires for non-admin users.
+  - Verify retry endpoint state guard (only 'failed' status).
+  - Verify manual endpoint validates order/split existence and refund amount caps.
+  - Verify the audit-log side effect on retry/manual.
+
+Heavy pieces (the list endpoint's enrichment with book titles, dispute
+join, trigger inference) are NOT covered here — that's a lot of cross-table
+plumbing for low test value. We do confirm the endpoint responds and
+returns the KPI shape.
+"""
+
+import pytest
+
+
+LIST_URL = "/api/v1/payment_gateway/refunds/admin"
+RETRY_URL = "/api/v1/payment_gateway/refunds/admin/{refund_id}/retry"
+MANUAL_URL = "/api/v1/payment_gateway/refunds/admin/manual"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def admin_user(make_user):
+    return make_user(name="Admin Alice", is_admin=True)
+
+
+@pytest.fixture
+def regular_user(make_user):
+    return make_user(name="Carl Customer", is_admin=False)
+
+
+@pytest.fixture
+def lender(make_user):
+    return make_user(name="Lender Linda")
+
+
+@pytest.fixture
+def borrower(make_user):
+    return make_user(name="Borrower Bob")
+
+
+# ===========================================================================
+# Admin auth gate
+# ===========================================================================
+
+class TestAdminAuthGate:
+    def test_non_admin_user_gets_403_on_list(
+        self, client, auth_as, regular_user, admin_refund_schema,
+    ):
+        auth_as(regular_user)
+        res = client.get(LIST_URL)
+        assert res.status_code == 403
+        assert "Admin" in res.json()["detail"]
+
+    def test_admin_user_passes_auth_gate(
+        self, client, auth_as, admin_user, admin_refund_schema,
+    ):
+        auth_as(admin_user)
+        res = client.get(LIST_URL)
+        # Auth passed even if no data — endpoint returns 200 with empty list
+        assert res.status_code == 200
+
+
+# ===========================================================================
+# GET /refunds/admin — light coverage
+# ===========================================================================
+
+class TestAdminRefundList:
+    def test_response_has_kpi_pagination_and_refunds_keys(
+        self, client, auth_as, admin_user, admin_refund_schema,
+    ):
+        auth_as(admin_user)
+        res = client.get(LIST_URL)
+
+        assert res.status_code == 200
+        body = res.json()
+        # Top-level shape contract — frontend depends on these keys
+        assert set(body.keys()) >= {"kpi", "pagination", "refunds"}
+        assert set(body["kpi"].keys()) >= {
+            "total_count", "total_amount", "succeeded_count",
+            "failed_count", "pending_count", "success_rate",
+        }
+        assert set(body["pagination"].keys()) >= {
+            "page", "page_size", "total", "total_pages",
+        }
+
+    def test_kpi_counts_reflect_my_added_refunds(
+        self, client, auth_as, admin_user, make_refund, admin_refund_schema,
+    ):
+        """
+        Add a known set of refunds and verify the KPI counts went UP by at
+        least that many. Uses delta-style assertions because the in-memory
+        sqlite engine carries leftover Refund rows from other tests
+        (see feedback_test_isolation memory).
+        """
+        auth_as(admin_user)
+        before = client.get(LIST_URL).json()["kpi"]
+
+        # Three refunds: 2 succeeded + 1 failed
+        make_refund(payment_id="pi_kpi_1", status="succeeded", amount=1000)
+        make_refund(payment_id="pi_kpi_2", status="succeeded", amount=2000)
+        make_refund(payment_id="pi_kpi_3", status="failed", amount=500)
+
+        after = client.get(LIST_URL).json()["kpi"]
+
+        assert after["total_count"] - before["total_count"] >= 3
+        assert after["succeeded_count"] - before["succeeded_count"] >= 2
+        assert after["failed_count"] - before["failed_count"] >= 1
+        assert after["total_amount"] - before["total_amount"] >= 3500
+
+
+# ===========================================================================
+# POST /refunds/admin/{refund_id}/retry
+# ===========================================================================
+
+class TestAdminRefundRetry:
+    def test_404_when_refund_not_found(
+        self, client, auth_as, admin_user, admin_refund_schema,
+    ):
+        auth_as(admin_user)
+        res = client.post(RETRY_URL.format(refund_id="re_does_not_exist"))
+        assert res.status_code == 404
+
+    def test_400_when_refund_status_not_failed(
+        self, client, auth_as, admin_user, make_refund,
+    ):
+        """Retry is only valid for 'failed' refunds — succeeded/pending should reject."""
+        refund = make_refund(payment_id="pi_succeeded", status="succeeded")
+        auth_as(admin_user)
+
+        res = client.post(RETRY_URL.format(refund_id=refund.refund_id))
+        assert res.status_code == 400
+        assert "failed" in res.json()["detail"].lower()
+
+    def test_happy_path_retries_failed_refund(
+        self, client, auth_as, admin_user, make_refund, stripe_refund_recorder, db,
+    ):
+        """
+        A failed refund + retry → Stripe.Refund.create called once, refund_id
+        replaced with new id, an admin_retry_refund audit log row written.
+        """
+        from models.payment_gateway import Refund, AuditLog
+
+        refund = make_refund(
+            payment_id="pi_retry",
+            status="failed",
+            amount=1500,
+            reason="Original failure",
+        )
+        old_refund_id = refund.refund_id
+
+        auth_as(admin_user)
+        res = client.post(RETRY_URL.format(refund_id=old_refund_id))
+
+        assert res.status_code == 200
+        body = res.json()
+        assert body["old_refund_id"] == old_refund_id
+        assert body["new_refund_id"] != old_refund_id
+        assert body["amount"] == 1500
+        assert body["status"] == "succeeded"
+
+        # Stripe was hit once with the failed refund's payment_id and amount
+        assert len(stripe_refund_recorder) == 1
+        call = stripe_refund_recorder[0]
+        assert call["payment_intent"] == "pi_retry"
+        assert call["amount"] == 1500
+
+        # Refund row is updated with new Stripe id (NOT a new row)
+        db.expire_all()  # invalidate cached objects so we re-read from DB
+        refresh_refund = (
+            db.query(Refund)
+            .filter(Refund.refund_id == body["new_refund_id"])
+            .first()
+        )
+        assert refresh_refund is not None
+        assert refresh_refund.amount == 1500
+
+        # Audit log written
+        log = (
+            db.query(AuditLog)
+            .filter(
+                AuditLog.event_type == "admin_retry_refund",
+                AuditLog.actor == admin_user.user_id,
+            )
+            .order_by(AuditLog.id.desc())
+            .first()
+        )
+        assert log is not None
+        assert old_refund_id in log.message
+        assert body["new_refund_id"] in log.message
+
+
+# ===========================================================================
+# POST /refunds/admin/manual
+# ===========================================================================
+
+class TestAdminManualRefund:
+    def test_404_when_order_not_found(
+        self, client, auth_as, admin_user, admin_refund_schema,
+    ):
+        auth_as(admin_user)
+        res = client.post(MANUAL_URL, json={
+            "order_id": "ghost-order-id",
+            "refund_type": "full",
+            "reason": "test",
+        })
+        assert res.status_code == 404
+        assert "Order" in res.json()["detail"]
+
+    def test_404_when_payment_split_missing(
+        self, client, auth_as, admin_user, make_order, lender, borrower,
+    ):
+        """Order exists but no PaymentSplit → 404 referencing payment split."""
+        order = make_order(owner=lender, borrower=borrower)
+        auth_as(admin_user)
+
+        res = client.post(MANUAL_URL, json={
+            "order_id": order.id,
+            "refund_type": "full",
+            "reason": "test",
+        })
+        assert res.status_code == 404
+        assert "Payment split" in res.json()["detail"]
+
+    def test_happy_path_full_refund(
+        self, client, auth_as, admin_user, make_order, make_payment_split,
+        lender, borrower, stripe_refund_recorder, db,
+    ):
+        """
+        Full refund: Stripe gets called with deposit + shipping cents,
+        Refund row persisted, audit log written, borrower notified.
+        """
+        from models.payment_gateway import Refund, AuditLog
+        from models.system_notification import SystemNotification
+
+        order = make_order(owner=lender, borrower=borrower, deposit_cents=2000)
+        make_payment_split(
+            order_id=order.id, payment_id=order.payment_id,
+            deposit_cents=2000, shipping_cents=500,
+        )
+        auth_as(admin_user)
+
+        res = client.post(MANUAL_URL, json={
+            "order_id": order.id,
+            "refund_type": "full",
+            "reason": "Customer goodwill",
+        })
+
+        assert res.status_code == 201
+        # Stripe called with deposit + shipping = 2500
+        assert len(stripe_refund_recorder) == 1
+        assert stripe_refund_recorder[0]["amount"] == 2500
+
+        # Refund row persisted with the right amount
+        refund_rows = db.query(Refund).filter(
+            Refund.payment_id == order.payment_id,
+            Refund.amount == 2500,
+        ).all()
+        assert len(refund_rows) >= 1
+
+        # Audit log: manual_refund event tied to this admin + order, message
+        # carries the type and amount so an auditor can reconstruct the call.
+        log = (
+            db.query(AuditLog)
+            .filter(
+                AuditLog.event_type == "manual_refund",
+                AuditLog.actor == admin_user.user_id,
+                AuditLog.reference_id == order.id,
+            )
+            .order_by(AuditLog.id.desc())
+            .first()
+        )
+        assert log is not None
+        assert "full" in log.message
+        assert "2500" in log.message
+        assert "Customer goodwill" in log.message
+
+        # Borrower received a REFUND notification scoped to this order
+        borrower_notifs = (
+            db.query(SystemNotification)
+            .filter(
+                SystemNotification.user_id == borrower.user_id,
+                SystemNotification.order_id == order.id,
+                SystemNotification.type == "REFUND",
+            )
+            .all()
+        )
+        assert len(borrower_notifs) == 1
+        assert "25.00" in borrower_notifs[0].message  # ${amount/100:.2f}
+
+    def test_deposit_only_refund_amount(
+        self, client, auth_as, admin_user, make_order, make_payment_split,
+        lender, borrower, stripe_refund_recorder,
+    ):
+        """refund_type='deposit' refunds ONLY deposit_cents, ignoring shipping."""
+        order = make_order(owner=lender, borrower=borrower)
+        make_payment_split(
+            order_id=order.id, payment_id=order.payment_id,
+            deposit_cents=3000, shipping_cents=700,
+        )
+        auth_as(admin_user)
+
+        res = client.post(MANUAL_URL, json={
+            "order_id": order.id,
+            "refund_type": "deposit",
+            "reason": "Deposit only",
+        })
+
+        assert res.status_code == 201
+        assert stripe_refund_recorder[0]["amount"] == 3000
+
+    def test_400_when_refund_amount_zero(
+        self, client, auth_as, admin_user, make_order, make_payment_split,
+        lender, borrower, stripe_refund_recorder,
+    ):
+        """Splits with zero shipping → shipping refund is 0 → 400 'No refundable amount'."""
+        order = make_order(owner=lender, borrower=borrower)
+        make_payment_split(
+            order_id=order.id, payment_id=order.payment_id,
+            deposit_cents=2000, shipping_cents=0,
+        )
+        auth_as(admin_user)
+
+        res = client.post(MANUAL_URL, json={
+            "order_id": order.id,
+            "refund_type": "shipping",
+            "reason": "Refund shipping",
+        })
+
+        assert res.status_code == 400
+        assert "No refundable amount" in res.json()["detail"]
+        # Stripe was never called
+        assert stripe_refund_recorder == []
+
+    def test_400_when_refund_would_exceed_payment_amount(
+        self, client, auth_as, admin_user, make_order, make_payment_split,
+        make_refund, lender, borrower, stripe_refund_recorder,
+    ):
+        """
+        If the order's payment was already fully refunded, attempting another
+        full refund should be rejected with 400.
+        """
+        order = make_order(owner=lender, borrower=borrower, deposit_cents=2000)
+        make_payment_split(
+            order_id=order.id, payment_id=order.payment_id,
+            deposit_cents=2000, shipping_cents=0,
+        )
+        # Pre-existing succeeded refund of the full amount
+        make_refund(payment_id=order.payment_id, status="succeeded", amount=2000)
+
+        auth_as(admin_user)
+        res = client.post(MANUAL_URL, json={
+            "order_id": order.id,
+            "refund_type": "full",
+            "reason": "Double refund attempt",
+        })
+
+        assert res.status_code == 400
+        assert "exceed" in res.json()["detail"].lower()
+        # No NEW Stripe call
+        assert stripe_refund_recorder == []

--- a/fastapi/tests/test_create_order_restriction.py
+++ b/fastapi/tests/test_create_order_restriction.py
@@ -1,0 +1,217 @@
+"""
+Tests for the MVP6-1 `is_restricted` guard in routes/order.py::create_order.
+
+Spec (locked): a borrower whose `is_restricted=True` cannot start any new
+borrow flow. The check fires when the linked checkout has at least one
+CheckoutItem with action_type='borrow' (case-insensitive). Pure-purchase
+checkouts pass through to the normal order-creation pipeline.
+
+These tests exercise the route via FastAPI TestClient with `get_db` and
+`get_current_user` overridden, and `OrderService.create_orders_data_with_validation`
+mocked — the goal is to verify the GUARD's behaviour, not the downstream
+order-creation logic (which has its own broader concerns).
+"""
+
+import pytest
+from types import SimpleNamespace
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+CREATE_ORDER_URL = "/api/v1/orders/"
+
+
+@pytest.fixture
+def regular_user(make_user):
+    return make_user(name="Alice Allowed", is_restricted=False)
+
+
+@pytest.fixture
+def restricted_user(make_user):
+    return make_user(
+        name="Restricted Bob",
+        is_restricted=True,
+        restriction_reason="Auto-restricted: 3 damage strikes, severity score 4.",
+    )
+
+
+@pytest.fixture
+def stub_create_orders(monkeypatch):
+    """
+    Replace OrderService.create_orders_data_with_validation with a no-op stub
+    that returns a single SimpleNamespace order. This isolates the guard test
+    from the full order-creation pipeline (Stripe, books, payment splits, etc).
+
+    Returns the call list so tests can assert whether the service was reached.
+    """
+    from services.order_service import OrderService
+
+    calls = []
+
+    def _stub(db, *, checkout_id, user_id, payment_id):
+        calls.append({"checkout_id": checkout_id, "user_id": user_id,
+                      "payment_id": payment_id})
+        return [SimpleNamespace(id=f"order-{len(calls)}")]
+
+    monkeypatch.setattr(
+        OrderService,
+        "create_orders_data_with_validation",
+        staticmethod(_stub),
+    )
+    return calls
+
+
+# ===========================================================================
+# Guard FIRES: restricted user attempting to borrow → 403
+# ===========================================================================
+
+class TestRestrictedBorrowBlocked:
+    def test_pure_borrow_checkout_returns_403(
+        self, client, auth_as, restricted_user, make_checkout, stub_create_orders,
+    ):
+        co = make_checkout(user=restricted_user, items=[("BORROW",)])
+        auth_as(restricted_user)
+
+        res = client.post(CREATE_ORDER_URL, json={
+            "checkout_id": co.checkout_id,
+            "payment_id": "pi_test_irrelevant",
+        })
+
+        assert res.status_code == 403
+        # Downstream service was NOT reached
+        assert stub_create_orders == []
+
+    def test_403_detail_carries_restriction_reason(
+        self, client, auth_as, restricted_user, make_checkout, stub_create_orders,
+    ):
+        """
+        The user-facing error should explain WHY they're blocked. Production
+        code reads `current_user.restriction_reason`; verify it's surfaced.
+        """
+        co = make_checkout(user=restricted_user, items=[("BORROW",)])
+        auth_as(restricted_user)
+
+        res = client.post(CREATE_ORDER_URL, json={
+            "checkout_id": co.checkout_id,
+            "payment_id": "pi_test_irrelevant",
+        })
+
+        assert res.status_code == 403
+        assert "3 damage strikes" in res.json()["detail"]
+
+    def test_403_detail_falls_back_when_reason_is_null(
+        self, client, auth_as, make_user, make_checkout, stub_create_orders,
+    ):
+        """If restriction_reason is somehow NULL, a generic message is used."""
+        user = make_user(is_restricted=True, restriction_reason=None)
+        co = make_checkout(user=user, items=[("BORROW",)])
+        auth_as(user)
+
+        res = client.post(CREATE_ORDER_URL, json={
+            "checkout_id": co.checkout_id,
+            "payment_id": "pi_test_irrelevant",
+        })
+
+        assert res.status_code == 403
+        assert "restricted" in res.json()["detail"].lower()
+
+    def test_mixed_borrow_and_purchase_still_blocks(
+        self, client, auth_as, restricted_user, make_checkout, stub_create_orders,
+    ):
+        """
+        Even ONE borrow item in a multi-item cart triggers the guard. The
+        user can't bypass restriction by adding a purchase to the cart.
+        """
+        co = make_checkout(
+            user=restricted_user,
+            items=[("PURCHASE",), ("BORROW",), ("PURCHASE",)],
+        )
+        auth_as(restricted_user)
+
+        res = client.post(CREATE_ORDER_URL, json={
+            "checkout_id": co.checkout_id,
+            "payment_id": "pi_test_irrelevant",
+        })
+
+        assert res.status_code == 403
+        assert stub_create_orders == []
+
+    def test_lowercase_action_type_also_blocked(
+        self, client, auth_as, restricted_user, make_checkout, stub_create_orders,
+    ):
+        """
+        Production filter uses `func.lower(action_type) == "borrow"` for
+        case-insensitive matching — guard against any future regression that
+        replaces this with a strict-case comparison.
+        """
+        co = make_checkout(user=restricted_user, items=[("borrow",)])
+        auth_as(restricted_user)
+
+        res = client.post(CREATE_ORDER_URL, json={
+            "checkout_id": co.checkout_id,
+            "payment_id": "pi_test_irrelevant",
+        })
+
+        assert res.status_code == 403
+        assert stub_create_orders == []
+
+
+# ===========================================================================
+# Guard PASSES: scenarios that should NOT 403
+# ===========================================================================
+
+class TestGuardPasses:
+    def test_unrestricted_user_borrowing_passes(
+        self, client, auth_as, regular_user, make_checkout, stub_create_orders,
+    ):
+        co = make_checkout(user=regular_user, items=[("BORROW",)])
+        auth_as(regular_user)
+
+        res = client.post(CREATE_ORDER_URL, json={
+            "checkout_id": co.checkout_id,
+            "payment_id": "pi_test_xyz",
+        })
+
+        assert res.status_code == 201
+        assert len(stub_create_orders) == 1
+        # Service was called with the correct checkout & user
+        assert stub_create_orders[0]["checkout_id"] == co.checkout_id
+        assert stub_create_orders[0]["user_id"] == regular_user.user_id
+
+    def test_restricted_user_pure_purchase_passes(
+        self, client, auth_as, restricted_user, make_checkout, stub_create_orders,
+    ):
+        """
+        Spec: deposit policy penalises borrowing behaviour, not buying.
+        A restricted user can still buy a book outright.
+        """
+        co = make_checkout(user=restricted_user, items=[("PURCHASE",)])
+        auth_as(restricted_user)
+
+        res = client.post(CREATE_ORDER_URL, json={
+            "checkout_id": co.checkout_id,
+            "payment_id": "pi_test_xyz",
+        })
+
+        assert res.status_code == 201
+        assert len(stub_create_orders) == 1
+
+    def test_restricted_user_mixed_purchases_only_passes(
+        self, client, auth_as, restricted_user, make_checkout, stub_create_orders,
+    ):
+        """Multi-item, all PURCHASE — guard does not fire."""
+        co = make_checkout(
+            user=restricted_user,
+            items=[("PURCHASE",), ("PURCHASE",), ("PURCHASE",)],
+        )
+        auth_as(restricted_user)
+
+        res = client.post(CREATE_ORDER_URL, json={
+            "checkout_id": co.checkout_id,
+            "payment_id": "pi_test_xyz",
+        })
+
+        assert res.status_code == 201
+        assert len(stub_create_orders) == 1

--- a/fastapi/tests/test_deposit_arbitration.py
+++ b/fastapi/tests/test_deposit_arbitration.py
@@ -1,0 +1,362 @@
+"""
+Integration tests for deposit_service admin arbitration actions (MVP6-1):
+
+  - admin_release      → 100% refund to borrower, severity='none'
+  - admin_deduct       → partial refund (light=25% / medium=50% kept by lender)
+  - admin_forfeit      → 0% refund, lender keeps full deposit, severity='severe'
+
+These are NOT pure unit tests; they exercise the full code path against a
+sqlite-in-memory schema with real ORM rows for User/Order/Payment/Refund/
+DepositAuditLog/SystemNotification. Stripe is mocked via `stripe_refund_recorder`
+so we can assert the exact `(payment_intent, amount)` it was called with.
+"""
+
+import pytest
+from fastapi import HTTPException
+
+from services.deposit_service import (
+    admin_release,
+    admin_deduct,
+    admin_forfeit,
+    DEDUCTION_PCT,
+)
+from models.deposit_audit_log import DepositAuditLog
+from models.payment_gateway import Refund, Payment
+from models.system_notification import SystemNotification
+
+
+# ---------------------------------------------------------------------------
+# Test scaffolding helpers
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def lender(make_user):
+    return make_user(name="Lender Linda")
+
+
+@pytest.fixture
+def borrower_for_arbitration(make_user):
+    """Borrower user dedicated to arbitration tests (clean strike state)."""
+    return make_user(name="Bob Borrower")
+
+
+@pytest.fixture
+def admin_actor(make_user):
+    return make_user(name="Admin Alice", is_admin=True)
+
+
+def _audit_logs_for(db, order_id, action=None):
+    q = db.query(DepositAuditLog).filter(DepositAuditLog.order_id == order_id)
+    if action:
+        q = q.filter(DepositAuditLog.action == action)
+    return q.all()
+
+
+def _notifs_for(db, user_id):
+    return (
+        db.query(SystemNotification)
+        .filter(SystemNotification.user_id == user_id)
+        .order_by(SystemNotification.title)
+        .all()
+    )
+
+
+# ===========================================================================
+# admin_release
+# ===========================================================================
+
+class TestAdminRelease:
+    def test_happy_path_refunds_full_deposit(
+        self, db, make_order, lender, borrower_for_arbitration, admin_actor,
+        stripe_refund_recorder,
+    ):
+        order = make_order(owner=lender, borrower=borrower_for_arbitration,
+                           deposit_cents=2000)
+        order_id = order.id
+        payment_id = order.payment_id
+
+        result = admin_release(db, order_id, admin_actor, note="Looks fine")
+
+        # Stripe was called once with the full deposit amount
+        assert len(stripe_refund_recorder) == 1
+        assert stripe_refund_recorder[0]["payment_intent"] == payment_id
+        assert stripe_refund_recorder[0]["amount"] == 2000
+
+        # Order state mutated
+        db.refresh(order)
+        assert order.deposit_status == "released"
+        assert order.deposit_deducted_cents == 0
+        assert order.damage_severity_final == "none"
+
+        # Refund row persisted
+        refunds = db.query(Refund).filter(Refund.payment_id == payment_id).all()
+        assert len(refunds) == 1
+        assert refunds[0].amount == 2000
+        assert refunds[0].status == "succeeded"
+
+        # Payment marked refunded (full refund == payment.amount)
+        payment = db.query(Payment).filter(Payment.payment_id == payment_id).first()
+        assert payment.status == "refunded"
+
+        # Audit log: 1 release entry, no restrict entry
+        logs = _audit_logs_for(db, order_id)
+        assert len(logs) == 1
+        assert logs[0].action == "release"
+        assert logs[0].final_severity == "none"
+        assert logs[0].amount_cents == 2000
+        assert logs[0].note == "Looks fine"
+
+        # Both parties notified (DEPOSIT_UPDATED)
+        lender_notifs = _notifs_for(db, lender.user_id)
+        borrower_notifs = _notifs_for(db, borrower_for_arbitration.user_id)
+        assert len(lender_notifs) == 1
+        assert len(borrower_notifs) == 1
+        assert lender_notifs[0].type == "DEPOSIT_UPDATED"
+        assert borrower_notifs[0].type == "DEPOSIT_UPDATED"
+
+        # Borrower NOT struck (release means no fault)
+        db.refresh(borrower_for_arbitration)
+        assert borrower_for_arbitration.damage_strike_count == 0
+        assert borrower_for_arbitration.damage_severity_score == 0
+        assert borrower_for_arbitration.is_restricted is False
+
+        # Return value shape
+        assert result["order_id"] == order_id
+        assert result["deposit_status"] == "released"
+        assert result["refunded_cents"] == 2000
+
+    def test_404_when_order_not_found(self, db, admin_actor, deposit_arbitration_schema):
+        with pytest.raises(HTTPException) as exc:
+            admin_release(db, "nonexistent-order-id", admin_actor)
+        assert exc.value.status_code == 404
+
+    def test_409_when_not_pending_review(
+        self, db, make_order, lender, borrower_for_arbitration, admin_actor,
+    ):
+        order = make_order(owner=lender, borrower=borrower_for_arbitration,
+                           deposit_status="released")
+        with pytest.raises(HTTPException) as exc:
+            admin_release(db, order.id, admin_actor)
+        assert exc.value.status_code == 409
+        assert "pending_review" in str(exc.value.detail)
+
+    def test_skips_stripe_when_no_payment_id(
+        self, db, make_order, lender, borrower_for_arbitration, admin_actor,
+        stripe_refund_recorder,
+    ):
+        order = make_order(owner=lender, borrower=borrower_for_arbitration,
+                           with_payment=False)
+
+        # Snapshot Refund count before the call so we can assert no NEW refund
+        # was created (rather than asserting the global count is 0 — which is
+        # fragile across tests sharing an in-memory sqlite engine; see the
+        # tech-debt note in conftest about sqlite + SAVEPOINT isolation).
+        refunds_before = db.query(Refund).count()
+
+        result = admin_release(db, order.id, admin_actor)
+
+        # Stripe never called
+        assert stripe_refund_recorder == []
+        # No NEW Refund row was created by this call
+        assert db.query(Refund).count() == refunds_before
+        # Order still moved to released (operationally complete)
+        db.refresh(order)
+        assert order.deposit_status == "released"
+        assert result["refunded_cents"] == 0
+
+
+# ===========================================================================
+# admin_deduct
+# ===========================================================================
+
+class TestAdminDeduct:
+    def test_light_deducts_25pct(
+        self, db, make_order, lender, borrower_for_arbitration, admin_actor,
+        stripe_refund_recorder,
+    ):
+        order = make_order(owner=lender, borrower=borrower_for_arbitration,
+                           deposit_cents=2000)
+
+        result = admin_deduct(db, order.id, admin_actor, severity="light")
+
+        # 25% kept (500), 75% refunded (1500)
+        assert stripe_refund_recorder[0]["amount"] == 1500
+        db.refresh(order)
+        assert order.deposit_status == "partially_deducted"
+        assert order.deposit_deducted_cents == 500
+        assert order.damage_severity_final == "light"
+        assert result["deducted_cents"] == 500
+        assert result["refunded_cents"] == 1500
+
+        # Strike applied (light = +1 count, +1 score)
+        db.refresh(borrower_for_arbitration)
+        assert borrower_for_arbitration.damage_strike_count == 1
+        assert borrower_for_arbitration.damage_severity_score == 1
+        # Below restrict thresholds — nothing escalated
+        assert borrower_for_arbitration.is_restricted is False
+        assert result["strike"]["restrict_applied"] is False
+        assert result["strike"]["suggest_ban"] is False
+        assert result["strike"]["auto_ban"] is False
+
+    def test_medium_deducts_50pct(
+        self, db, make_order, lender, borrower_for_arbitration, admin_actor,
+        stripe_refund_recorder,
+    ):
+        order = make_order(owner=lender, borrower=borrower_for_arbitration,
+                           deposit_cents=2000)
+
+        admin_deduct(db, order.id, admin_actor, severity="medium")
+
+        assert stripe_refund_recorder[0]["amount"] == 1000  # 50% refunded
+        db.refresh(order)
+        assert order.deposit_deducted_cents == 1000
+        assert order.damage_severity_final == "medium"
+
+        db.refresh(borrower_for_arbitration)
+        assert borrower_for_arbitration.damage_severity_score == 2  # medium weight
+
+    def test_third_deduct_triggers_restrict_and_audit(
+        self, db, make_order, lender, admin_actor, make_user, stripe_refund_recorder,
+    ):
+        """
+        Three consecutive light deducts on the same borrower must:
+          - bump strike_count to 3
+          - flip is_restricted=True
+          - produce a 'restrict' audit log entry on top of the 'partial_deduct' one
+          - return restrict_applied=True in the strike signal
+        """
+        borrower = make_user(name="Repeat Offender")
+        # Three separate orders so each can be in pending_review independently
+        o1 = make_order(owner=lender, borrower=borrower)
+        o2 = make_order(owner=lender, borrower=borrower)
+        o3 = make_order(owner=lender, borrower=borrower)
+
+        admin_deduct(db, o1.id, admin_actor, severity="light")
+        admin_deduct(db, o2.id, admin_actor, severity="light")
+        result = admin_deduct(db, o3.id, admin_actor, severity="light")
+
+        # Stripe must have been called once per deduct — guards against any
+        # short-circuit that would skip the partial refund call yet still
+        # bump the strike counter.
+        assert len(stripe_refund_recorder) == 3
+
+        db.refresh(borrower)
+        assert borrower.damage_strike_count == 3
+        assert borrower.is_restricted is True
+        assert result["strike"]["restrict_applied"] is True
+
+        # Third order's audit log has BOTH partial_deduct and restrict entries
+        o3_logs = _audit_logs_for(db, o3.id)
+        actions = sorted(log.action for log in o3_logs)
+        assert actions == ["partial_deduct", "restrict"]
+
+    def test_severe_severity_rejected_with_400(
+        self, db, make_order, lender, borrower_for_arbitration, admin_actor,
+    ):
+        order = make_order(owner=lender, borrower=borrower_for_arbitration)
+        with pytest.raises(HTTPException) as exc:
+            admin_deduct(db, order.id, admin_actor, severity="severe")
+        assert exc.value.status_code == 400
+        assert "light" in str(exc.value.detail) and "medium" in str(exc.value.detail)
+
+    def test_unknown_severity_rejected_with_400(
+        self, db, make_order, lender, borrower_for_arbitration, admin_actor,
+    ):
+        order = make_order(owner=lender, borrower=borrower_for_arbitration)
+        with pytest.raises(HTTPException) as exc:
+            admin_deduct(db, order.id, admin_actor, severity="catastrophic")
+        assert exc.value.status_code == 400
+
+    def test_404_when_borrower_missing(
+        self, db, make_order, lender, borrower_for_arbitration, admin_actor,
+        deposit_arbitration_schema,
+    ):
+        """
+        Guards a defensive code path that is unreachable in production with
+        FK enforcement — MySQL would reject the borrower_id update before
+        admin_deduct even runs. sqlite (no FK enforcement by default) lets
+        us reach the `if not borrower: raise 404` branch so the line is at
+        least exercised. Keep the test as a regression guard, not as proof
+        that prod can hit this path.
+        """
+        order = make_order(owner=lender, borrower=borrower_for_arbitration)
+        order.borrower_id = "ghost-user-id"
+        db.flush()
+
+        with pytest.raises(HTTPException) as exc:
+            admin_deduct(db, order.id, admin_actor, severity="light")
+        assert exc.value.status_code == 404
+        assert "Borrower" in str(exc.value.detail)
+
+    def test_deduction_pct_matches_locked_spec(self):
+        """Spec lock — teacher 2026-04-19: light=25%, medium=50%, severe=100%."""
+        assert DEDUCTION_PCT == {"light": 25, "medium": 50, "severe": 100}
+
+
+# ===========================================================================
+# admin_forfeit
+# ===========================================================================
+
+class TestAdminForfeit:
+    def test_happy_path_keeps_full_deposit(
+        self, db, make_order, lender, borrower_for_arbitration, admin_actor,
+        stripe_refund_recorder,
+    ):
+        order = make_order(owner=lender, borrower=borrower_for_arbitration,
+                           deposit_cents=2000)
+
+        result = admin_forfeit(db, order.id, admin_actor, note="No return")
+
+        # Stripe NEVER called (no refund — lender keeps everything)
+        assert stripe_refund_recorder == []
+
+        db.refresh(order)
+        assert order.deposit_status == "forfeited"
+        assert order.deposit_deducted_cents == 2000
+        assert order.damage_severity_final == "severe"
+
+        assert result["deducted_cents"] == 2000
+        assert result["refunded_cents"] == 0
+
+        # Strike applied with severe weight
+        db.refresh(borrower_for_arbitration)
+        assert borrower_for_arbitration.damage_strike_count == 1
+        assert borrower_for_arbitration.damage_severity_score == 3
+        # 1 strike, score=3 — below restrict threshold; suggest_ban=True (severe)
+        assert result["strike"]["restrict_applied"] is False
+        assert result["strike"]["suggest_ban"] is True
+
+        # Audit log
+        logs = _audit_logs_for(db, order.id)
+        assert len(logs) == 1
+        assert logs[0].action == "forfeit"
+        assert logs[0].final_severity == "severe"
+        assert logs[0].amount_cents == 2000
+        assert logs[0].note == "No return"
+
+    def test_forfeit_can_trigger_restrict(
+        self, db, make_order, lender, admin_actor, make_user, stripe_refund_recorder,
+    ):
+        """Borrower already at score 5: one severe forfeit (+3) -> score 8 >= 6 -> restrict."""
+        borrower = make_user(damage_strike_count=2, damage_severity_score=5)
+        order = make_order(owner=lender, borrower=borrower)
+
+        result = admin_forfeit(db, order.id, admin_actor)
+
+        db.refresh(borrower)
+        assert borrower.is_restricted is True
+        assert result["strike"]["restrict_applied"] is True
+
+        # Audit log includes restrict entry alongside forfeit
+        logs = _audit_logs_for(db, order.id)
+        actions = sorted(log.action for log in logs)
+        assert actions == ["forfeit", "restrict"]
+
+    def test_409_when_not_pending_review(
+        self, db, make_order, lender, borrower_for_arbitration, admin_actor,
+    ):
+        order = make_order(owner=lender, borrower=borrower_for_arbitration,
+                           deposit_status="forfeited")
+        with pytest.raises(HTTPException) as exc:
+            admin_forfeit(db, order.id, admin_actor)
+        assert exc.value.status_code == 409

--- a/fastapi/tests/test_deposit_strike.py
+++ b/fastapi/tests/test_deposit_strike.py
@@ -1,0 +1,309 @@
+"""
+Unit tests for `deposit_service._apply_strike` (MVP6-1).
+
+What this function does (paraphrased from services/deposit_service.py:109):
+  - Increments the borrower's damage_strike_count by 1.
+  - Increments damage_severity_score by STRIKE_WEIGHTS[severity]
+    (light=1, medium=2, severe=3).
+  - If the borrower isn't already restricted AND
+        strike_count >= 3 OR severity_score >= 6
+    → flips is_restricted=True, sets restriction_reason, fires a
+      USER_RESTRICTED notification (commit=False), and returns
+      restrict_applied=True.
+  - suggest_ban := (severity == 'severe')
+  - auto_ban    := (severity_score >= 10)
+
+Tests focus on the boundary conditions because that is where requirements
+were locked by the teacher (2026-04-19 spec). All NotificationService side
+effects are exercised against a real sqlite-in-memory DB to catch shape
+regressions.
+"""
+
+from services.deposit_service import (
+    _apply_strike,
+    AUTO_RESTRICT_STRIKE_THRESHOLD,
+    AUTO_RESTRICT_SCORE_THRESHOLD,
+    AUTO_BAN_SCORE_THRESHOLD,
+    STRIKE_WEIGHTS,
+)
+from models.system_notification import SystemNotification
+
+
+# ---------------------------------------------------------------------------
+# Counter increment + return shape
+# ---------------------------------------------------------------------------
+
+class TestStrikeCounters:
+    def test_light_increments_count_by_1_and_score_by_1(self, db, borrower):
+        result = _apply_strike(db, borrower, "light")
+
+        assert borrower.damage_strike_count == 1
+        assert borrower.damage_severity_score == 1
+        assert result["strike_count"] == 1
+        assert result["severity_score"] == 1
+
+    def test_medium_increments_count_by_1_and_score_by_2(self, db, borrower):
+        result = _apply_strike(db, borrower, "medium")
+
+        assert borrower.damage_strike_count == 1
+        assert borrower.damage_severity_score == 2
+        assert result["severity_score"] == 2
+
+    def test_severe_increments_count_by_1_and_score_by_3(self, db, borrower):
+        result = _apply_strike(db, borrower, "severe")
+
+        assert borrower.damage_strike_count == 1
+        assert borrower.damage_severity_score == 3
+        assert result["severity_score"] == 3
+
+    def test_unknown_severity_increments_count_but_not_score(self, db, borrower):
+        """STRIKE_WEIGHTS.get() returns 0 for unknown — defensive default."""
+        result = _apply_strike(db, borrower, "unknown_tier")
+
+        assert borrower.damage_strike_count == 1
+        assert borrower.damage_severity_score == 0
+        assert result["severity_score"] == 0
+
+    def test_consecutive_strikes_accumulate(self, db, borrower):
+        _apply_strike(db, borrower, "light")
+        _apply_strike(db, borrower, "medium")
+        result = _apply_strike(db, borrower, "light")
+
+        # 1 + 1 + 1 = 3 strikes; 1 + 2 + 1 = 4 score
+        assert borrower.damage_strike_count == 3
+        assert borrower.damage_severity_score == 4
+        assert result["strike_count"] == 3
+        assert result["severity_score"] == 4
+
+
+# ---------------------------------------------------------------------------
+# Auto-restrict thresholds
+# ---------------------------------------------------------------------------
+
+class TestAutoRestrictByStrikeCount:
+    """Threshold: 3 strikes (regardless of score)."""
+
+    def test_below_threshold_does_not_restrict(self, db, borrower):
+        # 2 light strikes: count=2, score=2 — both below thresholds
+        _apply_strike(db, borrower, "light")
+        result = _apply_strike(db, borrower, "light")
+
+        assert borrower.is_restricted is False
+        assert result["restrict_applied"] is False
+
+    def test_third_strike_triggers_restrict(self, db, borrower):
+        # 3 light strikes: count=3 (= threshold), score=3 (below score threshold)
+        _apply_strike(db, borrower, "light")
+        _apply_strike(db, borrower, "light")
+        result = _apply_strike(db, borrower, "light")
+
+        assert borrower.is_restricted is True
+        assert result["restrict_applied"] is True
+        assert "3 damage strikes" in (borrower.restriction_reason or "")
+
+    def test_strike_threshold_uses_constant(self):
+        """Guard against accidental constant changes; spec is locked at 3."""
+        assert AUTO_RESTRICT_STRIKE_THRESHOLD == 3
+
+
+class TestAutoRestrictBySeverityScore:
+    """Threshold: severity_score >= 6 (regardless of strike count)."""
+
+    def test_two_medium_below_score_threshold(self, db, borrower):
+        # 2 medium: count=2, score=4 — below both thresholds
+        _apply_strike(db, borrower, "medium")
+        result = _apply_strike(db, borrower, "medium")
+
+        assert borrower.is_restricted is False
+        assert result["restrict_applied"] is False
+
+    def test_score_path_triggers_with_count_far_below_threshold(self, db, make_user):
+        """
+        Pure score-path test: pre-load score=5, count=1; +medium → score=7,
+        count=2. count is still well below the strike threshold (3), so the
+        ONLY way restrict can fire is via the score branch. If the strike-count
+        check is accidentally removed/broken, this test still proves the score
+        branch is wired correctly.
+        """
+        borrower = make_user(damage_strike_count=1, damage_severity_score=5)
+
+        result = _apply_strike(db, borrower, "medium")
+
+        assert borrower.damage_strike_count == 2          # below count threshold
+        assert borrower.damage_severity_score == 7        # above score threshold
+        assert borrower.is_restricted is True
+        assert result["restrict_applied"] is True
+        assert "severity score 7" in (borrower.restriction_reason or "")
+
+    def test_score_threshold_uses_constant(self):
+        assert AUTO_RESTRICT_SCORE_THRESHOLD == 6
+
+
+class TestAlreadyRestricted:
+    """If borrower is already restricted, restrict_applied stays False."""
+
+    def test_already_restricted_does_not_re_apply(self, db, make_user):
+        borrower = make_user(
+            damage_strike_count=5,
+            damage_severity_score=8,
+            is_restricted=True,
+            restriction_reason="Manually restricted by admin",
+        )
+        result = _apply_strike(db, borrower, "medium")
+
+        # Counters still bump, but restrict_applied stays False
+        assert borrower.damage_strike_count == 6
+        assert borrower.damage_severity_score == 10
+        assert result["restrict_applied"] is False
+        # restriction_reason is NOT overwritten
+        assert "Manually restricted by admin" in (borrower.restriction_reason or "")
+
+
+# ---------------------------------------------------------------------------
+# suggest_ban / auto_ban signals
+# ---------------------------------------------------------------------------
+
+class TestSuggestBan:
+    def test_severe_severity_sets_suggest_ban(self, db, borrower):
+        result = _apply_strike(db, borrower, "severe")
+        assert result["suggest_ban"] is True
+
+    def test_light_does_not_set_suggest_ban(self, db, borrower):
+        result = _apply_strike(db, borrower, "light")
+        assert result["suggest_ban"] is False
+
+    def test_medium_does_not_set_suggest_ban(self, db, borrower):
+        result = _apply_strike(db, borrower, "medium")
+        assert result["suggest_ban"] is False
+
+
+class TestAutoBan:
+    """auto_ban is purely a function of severity_score >= 10."""
+
+    def test_score_below_10_no_auto_ban(self, db, make_user):
+        borrower = make_user(damage_severity_score=6)
+        result = _apply_strike(db, borrower, "light")  # → score 7
+
+        assert result["auto_ban"] is False
+
+    def test_score_exactly_10_triggers_auto_ban(self, db, make_user):
+        borrower = make_user(damage_severity_score=8)
+        result = _apply_strike(db, borrower, "medium")  # → score 10
+
+        assert borrower.damage_severity_score == 10
+        assert result["auto_ban"] is True
+
+    def test_score_above_10_triggers_auto_ban(self, db, make_user):
+        borrower = make_user(damage_severity_score=9)
+        result = _apply_strike(db, borrower, "severe")  # → score 12
+
+        assert result["auto_ban"] is True
+
+    def test_auto_ban_threshold_uses_constant(self):
+        assert AUTO_BAN_SCORE_THRESHOLD == 10
+
+
+class TestSignalIndependence:
+    """The three signals are independent — each can fire alone or together."""
+
+    def test_severe_first_strike_only_suggests_ban(self, db, borrower):
+        # 1 severe: count=1, score=3 — below restrict + below auto-ban
+        result = _apply_strike(db, borrower, "severe")
+
+        assert result["restrict_applied"] is False
+        assert result["suggest_ban"] is True
+        assert result["auto_ban"] is False
+
+    def test_count_threshold_and_severe_fire_together(self, db, make_user):
+        # Pre-state: count=2, score=5 (both still below thresholds).
+        # +severe → count=3 (hit strike threshold), score=8 (below auto-ban),
+        #   severity=severe (suggest_ban). restrict + suggest_ban fire; auto_ban does not.
+        borrower = make_user(damage_strike_count=2, damage_severity_score=5)
+        result = _apply_strike(db, borrower, "severe")
+
+        assert result["restrict_applied"] is True
+        assert result["suggest_ban"] is True
+        assert result["auto_ban"] is False
+
+    def test_all_three_signals_can_fire_at_once(self, db, make_user):
+        # Pre-state: count=2, score=8 (just below restrict by score, below ban)
+        # Apply severe → count=3 (hit restrict), score=11 (hit auto-ban),
+        # severity=severe (suggest_ban)
+        borrower = make_user(
+            damage_strike_count=2,
+            damage_severity_score=8,
+            is_restricted=False,
+        )
+        result = _apply_strike(db, borrower, "severe")
+
+        assert result["restrict_applied"] is True
+        assert result["suggest_ban"] is True
+        assert result["auto_ban"] is True
+
+
+# ---------------------------------------------------------------------------
+# USER_RESTRICTED notification side effect
+# ---------------------------------------------------------------------------
+
+class TestRestrictionNotification:
+    """
+    NotificationService.create is called with commit=False, so the row is in
+    the session but not flushed. The production session is autoflush=False
+    (database/connection.py), so we mirror that here by explicitly flushing
+    before asserting — same flush boundary that admin_deduct's db.commit()
+    would cross in real code.
+    """
+
+    def test_restriction_creates_notification(self, db, borrower):
+        # Cross threshold with 3 light strikes
+        _apply_strike(db, borrower, "light")
+        _apply_strike(db, borrower, "light")
+        _apply_strike(db, borrower, "light")
+        db.flush()
+
+        notifs = (
+            db.query(SystemNotification)
+            .filter(SystemNotification.user_id == borrower.user_id)
+            .all()
+        )
+        assert len(notifs) == 1
+        assert notifs[0].type == "USER_RESTRICTED"
+        assert "restricted" in notifs[0].title.lower()
+
+    def test_no_notification_when_below_threshold(self, db, borrower):
+        _apply_strike(db, borrower, "light")
+        _apply_strike(db, borrower, "light")
+        db.flush()
+
+        notifs = (
+            db.query(SystemNotification)
+            .filter(SystemNotification.user_id == borrower.user_id)
+            .all()
+        )
+        assert notifs == []
+
+    def test_no_duplicate_notification_when_already_restricted(self, db, make_user):
+        borrower = make_user(
+            damage_strike_count=5,
+            damage_severity_score=10,
+            is_restricted=True,
+        )
+        _apply_strike(db, borrower, "medium")
+        db.flush()
+
+        notifs = (
+            db.query(SystemNotification)
+            .filter(SystemNotification.user_id == borrower.user_id)
+            .all()
+        )
+        # No new USER_RESTRICTED notification — they're already restricted
+        assert notifs == []
+
+
+# ---------------------------------------------------------------------------
+# STRIKE_WEIGHTS source-of-truth check
+# ---------------------------------------------------------------------------
+
+def test_strike_weights_match_locked_spec():
+    """Weights are spec'd (teacher 2026-04-19): light=1, medium=2, severe=3."""
+    assert STRIKE_WEIGHTS == {"light": 1, "medium": 2, "severe": 3}

--- a/fastapi/tests/test_refund_functions.py
+++ b/fastapi/tests/test_refund_functions.py
@@ -29,6 +29,7 @@ def _make_order(
     payment_id="pi_test_123",
     books=None,
     total_refunded_amount=None,
+    total_paid_amount=25.00,   # dollars; refund_on_cancel uses to_cents(total_paid_amount)
 ):
     order = MagicMock()
     order.id = order_id
@@ -38,6 +39,11 @@ def _make_order(
     order.payment_id = payment_id
     order.canceled_at = None
     order.total_refunded_amount = total_refunded_amount
+    # total_paid_amount is the SOURCE OF TRUTH for refund_on_cancel (not
+    # PaymentSplit). Setting it explicitly is required — without this, the
+    # MagicMock attribute defaults to a truthy mock object and to_cents()
+    # returns a meaningless number, masking the real branch logic.
+    order.total_paid_amount = total_paid_amount
 
     # books relationship — list of OrderBook-like objects
     if books is None:
@@ -448,20 +454,66 @@ class TestRefundOnCancel:
 
     @patch("services.payment_gateway_service.stripe")
     def test_zero_amount_raises_400(self, mock_stripe):
-        """PaymentSplit with 0 refundable amount → 400."""
+        """Order.total_paid_amount = 0 → 400 (no refundable amount)."""
         from services.payment_gateway_service import refund_on_cancel
         from models.order import Order
         from models.payment_split import PaymentSplit
         from fastapi import HTTPException
 
-        order = _make_order(status="PENDING_SHIPMENT")
-        sp = _make_payment_split(deposit_cents=0, shipping_cents=0)
+        # NOTE: refund_on_cancel reads `Order.total_paid_amount`, NOT the
+        # PaymentSplit components. The split deposit/shipping are irrelevant
+        # to this branch — only total_paid_amount matters.
+        order = _make_order(status="PENDING_SHIPMENT", total_paid_amount=0)
+        sp = _make_payment_split()
         db = MagicMock()
         _mock_db_query(db, {Order: order, PaymentSplit: sp})
 
         with pytest.raises(HTTPException) as exc_info:
             refund_on_cancel(db, "order-001")
         assert exc_info.value.status_code == 400
+
+    @patch("services.payment_gateway_service.stripe")
+    def test_refund_includes_service_fee(self, mock_stripe):
+        """
+        Locked business rule (confirmed 2026-04-28): cancel-stage refunds
+        return EVERYTHING the user paid, including the platform service fee.
+        Platform earns less rather than withholding fees from a customer who
+        never received any service.
+
+        The implementation uses `Order.total_paid_amount` precisely because
+        that field is the post-PR-#88 source of truth — it equals
+        deposit + rental + shipping + service_fee (per checkout_service).
+        Using the older `PaymentSplit.deposit_cents + shipping_cents` would
+        silently exclude the service fee, short-changing the user.
+        """
+        from services.payment_gateway_service import refund_on_cancel
+        from models.order import Order
+        from models.payment_split import PaymentSplit
+        from models.payment_gateway import Payment
+        from models.book import Book
+
+        # Realistic figures: deposit $20 + shipping $5 + service fee $2 = $27
+        order = _make_order(status="PENDING_SHIPMENT", total_paid_amount=27.00)
+        sp = _make_payment_split(deposit_cents=2000, shipping_cents=500)
+        payment = _make_payment(amount=2700)
+        book = _make_book()
+        mock_stripe.Refund.create.return_value = _make_stripe_refund()
+
+        db = MagicMock()
+        _mock_db_query(db, {Order: order, PaymentSplit: sp, Payment: payment, Book: book})
+
+        result = refund_on_cancel(db, "order-001", actor="user-123")
+
+        # The headline assertion: refund AMOUNT must include the service fee
+        # (2700 cents, not 2500 — the +200 cents IS the service fee being returned).
+        mock_stripe.Refund.create.assert_called_once_with(
+            payment_intent="pi_test_123", amount=2700,
+        )
+        assert result["amount"] == 2700
+        # Defensive: prove the refund is STRICTLY greater than the
+        # split-only amount, so a future regression to the old formula
+        # would be caught.
+        assert result["amount"] > (sp.deposit_cents + sp.shipping_cents)
 
     @patch("services.payment_gateway_service.stripe")
     def test_already_refunded_idempotent(self, mock_stripe):


### PR DESCRIPTION
## Summary

Add a backend test suite covering MVP6 (Refund) and MVP6-1 (Deposit
Management). 61 new tests across four files, plus a one-line production
fix surfaced by the suite, plus cleanup of pre-existing test/impl drift
and stale doc comments left behind by PR #88.

**Net result**: 18 pass + 2 fail (baseline) → **80 pass + 0 fail** in ~3s.

## Changes by commit

1. **chore(gitignore)** — exclude personal D2 deliverables / draft design proposals so they stop polluting `git status`
2. **fix(deposit)** — `_persist_refund_record` was missing a `db.flush()` before its `SUM(Refund.amount)` cap query; with `autoflush=False`, full-amount refunds were always miscategorised as `partially_refunded`. One line.
3. **test infra** — `conftest.py`: sqlite-in-memory engine, layered opt-in schema fixtures (strike → arbitration → admin_refund / restriction_guard), Stripe recorder, FastAPI TestClient + `auth_as` helper
4. **MVP6 / MVP6-1 tests** — 4 files, 61 tests:
   - `test_deposit_strike.py` (26): `_apply_strike` boundary conditions, three-signal independence (restrict / suggest_ban / auto_ban), `USER_RESTRICTED` notification side effect
   - `test_deposit_arbitration.py` (14): `admin_release` / `admin_deduct` / `admin_forfeit` integration tests with real ORM rows + recording Stripe mock
   - `test_create_order_restriction.py` (8): HTTP-level coverage of the `is_restricted` guard via TestClient + dependency_overrides
   - `test_admin_refund_endpoints.py` (13): MVP6 Phase 3 admin refund list / retry / manual endpoints, including audit log + borrower notification side effects
5. **drift + docs** — fix two pre-existing failing tests in `test_refund_functions.py` (mock never set `total_paid_amount`, so the actual code path was never exercised); add a new `test_refund_includes_service_fee` that locks the business rule "cancel-stage refunds include service fee" so a regression to the older PaymentSplit-based formula would be caught; align two stale `5%` comments / docstring examples in `order_service.py` with the post-PR-#88 fixed-$2 model

## Production-relevant findings

- **Bug**: `services/deposit_service.py::_persist_refund_record` was miscategorising full refunds as `partially_refunded`. Fixed in commit 2.
- **Business rule locked into tests**: cancel-stage refunds return the entire `Order.total_paid_amount` (including the platform service fee). This is the implementation reality and was confirmed as the intended business rule on 2026-04-28.

## Test plan

- [x] Run `docker exec -w /app fastapi-backend python -m pytest tests/` locally → 80 passed
- [x] Verified the prod fix in commit 2 alone causes `test_happy_path_refunds_full_deposit` to flip from red to green
- [x] Verified the drift fix in commit 5 alone causes the pre-existing `TestRefundOnCancel::test_refund_successful` and `test_zero_amount_raises_400` to flip from red to green
- [x] Reviewer to spot-check that `_persist_refund_record`'s new `db.flush()` does not introduce unwanted commits in any caller (it does not — flush != commit; the same db.commit() at the end of admin_release/deduct/forfeit governs the transaction boundary)