### PR TITLE
fix(shipping): persist tracking modal, role-based shipping page, confirm-receipt banner

### DIFF
--- a/fastapi/models/order.py
+++ b/fastapi/models/order.py
@@ -193,8 +193,10 @@ class Order(Base):
             "completedAt": self._to_utc_iso(self.completed_at),
             "canceledAt": self._to_utc_iso(self.canceled_at),
             
+            "shippingOutCarrier": self.shipping_out_carrier,
             "shippingOutTrackingNumber": self.shipping_out_tracking_number,
             "shippingOutTrackingUrl": self.shipping_out_tracking_url,
+            "shippingReturnCarrier": self.shipping_return_carrier,
             "shippingReturnTrackingNumber": self.shipping_return_tracking_number,
             "shippingReturnTrackingUrl": self.shipping_return_tracking_url,
             

--- a/fastapi/schemas/order.py
+++ b/fastapi/schemas/order.py
@@ -93,15 +93,18 @@ class CreateOrderRequest(BaseModel):
 
 class TrackingNumberItem(BaseModel):
     order_id: str
-    shipping_out_tracking_number: Optional[str]
-    shipping_return_tracking_number: Optional[str]
+    leg: str  # "out" | "return"
+    role: str  # "sender" | "recipient" — relative to the requesting user
+    tracking_state: str  # "in_transit" | "delivered"
+    carrier: Optional[str] = None
+    tracking_number: Optional[str] = None
     book_title: Optional[str] = None
     counterpart_name: Optional[str] = None
     counterpart_role: Optional[str] = None
     created_at: Optional[datetime] = None
     updated_at: Optional[datetime] = None
-    start_at: Optional[datetime] = None
-    returned_at: Optional[datetime] = None
+    shipped_at: Optional[datetime] = None
+    delivered_at: Optional[datetime] = None
 
 class ConfirmShipmentRequest(BaseModel):
     tracking_number: str

--- a/fastapi/services/order_service.py
+++ b/fastapi/services/order_service.py
@@ -662,6 +662,11 @@ class OrderService:
                 commit=False,
             )
 
+            # Commit tracking number + notification now, before fee distribution,
+            # so a Stripe failure in distribute_shipping_fee can't rollback these changes.
+            db.commit()
+            db.refresh(order)
+
             try:
                 borrower_name = (order.borrower.name if order.borrower and order.borrower.name else "there")
                 owner_name = (order.owner.name if order.owner and order.owner.name else "there")
@@ -690,7 +695,7 @@ class OrderService:
             except Exception as e:
                 logger.warning("Failed to send shipment status emails: %s", e)
 
-            # implement distribute shipping fee function
+            # Distribute shipping fee via Stripe (best-effort, runs after commit above)
             try:
                 payment_id = order.payment_id
                 if payment_id:
@@ -698,6 +703,7 @@ class OrderService:
                     from services.payment_gateway_service import distribute_shipping_fee
                     distribute_shipping_fee(payment_id, data, db=db)
             except Exception as e:
+                db.rollback()
                 print(f"[WARN] distribute_shipping_fee failed: {e}")
                 
             

--- a/fastapi/services/order_service.py
+++ b/fastapi/services/order_service.py
@@ -456,18 +456,20 @@ class OrderService:
         target_user_id: Optional[str] = None
     ) -> List[Dict[str, Optional[str]]]:
         """
-        Return AUPOST shipping out and return tracking numbers per order for a user.
-        Each item includes order_id and tracking numbers (or None if not AUPOST).
+        Return one entry per shipment leg (outbound + return) the user is involved in.
 
-        Example:
-        [
-            {
-                "order_id": "ORD123",
-                "shipping_out_tracking_number": "OUT123",
-                "shipping_return_tracking_number": "RET123"
-            },
-            ...
-        ]
+        Each entry says whether the current user is the sender or recipient of that
+        leg, and whether the package is in transit or already delivered (the latter
+        meaning the recipient has confirmed receipt via the in-app flow).
+
+        Outbound leg: owner ships to borrower.
+            - in_transit  while order.status == PENDING_SHIPMENT
+            - delivered   once status moves past it (BORROWING / OVERDUE /
+                          RETURNED / COMPLETED), since the borrower had to
+                          confirm receipt to advance it.
+        Return leg: borrower ships back to owner.
+            - in_transit  while order.status == RETURNED
+            - delivered   once status == COMPLETED.
         """
         user_id = target_user_id or current_user.user_id
 
@@ -479,36 +481,77 @@ class OrderService:
             (Order.borrower_id == user_id) | (Order.owner_id == user_id)
         ).all()
 
-        result = []
+        # Status sets that decide whether each leg is in-transit vs delivered.
+        OUT_IN_TRANSIT = {"PENDING_SHIPMENT"}
+        OUT_DELIVERED = {"BORROWING", "OVERDUE", "RETURNED", "COMPLETED"}
+        RETURN_IN_TRANSIT = {"RETURNED"}
+        RETURN_DELIVERED = {"COMPLETED"}
+
+        result: List[Dict[str, Optional[str]]] = []
         for order in orders:
-            out_num = order.shipping_out_tracking_number if order.shipping_out_carrier == "AUSPOST" else None
-            return_num = order.shipping_return_tracking_number if order.shipping_return_carrier == "AUSPOST" else None
+            # Skip orders that never had a shipment (still pending payment) or
+            # were canceled — neither leg is meaningful.
+            if order.status in ("PENDING_PAYMENT", "CANCELED"):
+                continue
+
             first_book = next((ob.book for ob in order.books if ob.book), None)
-            book_title = None
-            if first_book:
-                book_title = first_book.title_or or first_book.title_en
+            book_title = (first_book.title_or or first_book.title_en) if first_book else None
+            owner_name = order.owner.name if order.owner else None
+            borrower_name = order.borrower.name if order.borrower else None
 
-            if order.owner_id == user_id:
-                counterpart_name = order.borrower.name if order.borrower else None
-                counterpart_role = "Borrower"
-            else:
-                counterpart_name = order.owner.name if order.owner else None
-                counterpart_role = "Owner"
+            # Outbound leg — only if the lender filled a tracking number.
+            if order.shipping_out_tracking_number:
+                if order.status in OUT_IN_TRANSIT:
+                    out_state = "in_transit"
+                elif order.status in OUT_DELIVERED:
+                    out_state = "delivered"
+                else:
+                    out_state = None  # unexpected, skip rather than mislabel
 
-            # Only include if at least one AUPOST tracking number exists
-            if out_num or return_num:
-                result.append({
-                    "order_id": order.id,
-                    "shipping_out_tracking_number": out_num,
-                    "shipping_return_tracking_number": return_num,
-                    "book_title": book_title,
-                    "counterpart_name": counterpart_name,
-                    "counterpart_role": counterpart_role,
-                    "created_at": order.created_at,
-                    "updated_at": order.updated_at,
-                    "start_at": order.start_at,
-                    "returned_at": order.returned_at,
-                })
+                if out_state is not None:
+                    is_owner = order.owner_id == user_id
+                    result.append({
+                        "order_id": order.id,
+                        "leg": "out",
+                        "role": "sender" if is_owner else "recipient",
+                        "tracking_state": out_state,
+                        "carrier": order.shipping_out_carrier,
+                        "tracking_number": order.shipping_out_tracking_number,
+                        "book_title": book_title,
+                        "counterpart_name": borrower_name if is_owner else owner_name,
+                        "counterpart_role": "Borrower" if is_owner else "Owner",
+                        "created_at": order.created_at,
+                        "updated_at": order.updated_at,
+                        "shipped_at": order.updated_at,
+                        "delivered_at": order.start_at if out_state == "delivered" else None,
+                    })
+
+            # Return leg — only if the borrower filed a return tracking number.
+            if order.shipping_return_tracking_number:
+                if order.status in RETURN_IN_TRANSIT:
+                    return_state = "in_transit"
+                elif order.status in RETURN_DELIVERED:
+                    return_state = "delivered"
+                else:
+                    return_state = None
+
+                if return_state is not None:
+                    is_borrower = order.borrower_id == user_id
+                    result.append({
+                        "order_id": order.id,
+                        "leg": "return",
+                        "role": "sender" if is_borrower else "recipient",
+                        "tracking_state": return_state,
+                        "carrier": order.shipping_return_carrier,
+                        "tracking_number": order.shipping_return_tracking_number,
+                        "book_title": book_title,
+                        "counterpart_name": owner_name if is_borrower else borrower_name,
+                        "counterpart_role": "Owner" if is_borrower else "Borrower",
+                        "created_at": order.created_at,
+                        "updated_at": order.updated_at,
+                        "shipped_at": order.returned_at,
+                        "delivered_at": order.completed_at if return_state == "delivered" else None,
+                    })
 
         return result
     

--- a/frontendNext/app/borrowing/[id]/page.tsx
+++ b/frontendNext/app/borrowing/[id]/page.tsx
@@ -165,6 +165,24 @@ export default function OrderDetailPage() {
     loadData();
   }, [id]);
 
+  // Hydrate ship modal fields from the persisted order so reopening the page
+  // doesn't make the user retype the tracking number / carrier they already saved.
+  useEffect(() => {
+    if (!order) return;
+    const isReturnLeg =
+      order.status === "BORROWING" ||
+      order.status === "OVERDUE" ||
+      order.status === "RETURNED";
+    const persistedTracking = isReturnLeg
+      ? order.shippingReturnTrackingNumber
+      : order.shippingOutTrackingNumber;
+    const persistedCarrier = isReturnLeg
+      ? order.shippingReturnCarrier
+      : order.shippingOutCarrier;
+    setTrackingNumber(persistedTracking || "");
+    setCarrier(persistedCarrier || "AUSPOST");
+  }, [order]);
+
   // Handle refund redirect from complaint form
   useEffect(() => {
     const action = searchParams.get("action");
@@ -511,6 +529,29 @@ export default function OrderDetailPage() {
           )}
         </div>
       </div>
+
+      {isBorrower &&
+        order.status === "PENDING_SHIPMENT" &&
+        order.shippingOutTrackingNumber && (
+          <div className="flex items-start gap-3 rounded-lg border border-blue-200 bg-blue-50 p-4">
+            <Truck className="mt-0.5 h-5 w-5 shrink-0 text-blue-600" />
+            <div className="flex-1 text-sm">
+              <p className="font-semibold text-blue-900">
+                Your book is on its way
+              </p>
+              <p className="mt-1 text-blue-800">
+                The lender has shipped this order. Once it arrives, please
+                confirm receipt so the lender knows it got there safely.
+              </p>
+            </div>
+            <Button
+              className="bg-blue-600 text-white hover:bg-blue-700 shrink-0"
+              onClick={() => setBorrowerConfirmReceiveModalOpen(true)}
+            >
+              Confirm Receive
+            </Button>
+          </div>
+        )}
 
       {/* Section 1 — Order Info */}
       <div className="grid md:grid-cols-2 gap-4">

--- a/frontendNext/app/lending/page.tsx
+++ b/frontendNext/app/lending/page.tsx
@@ -255,7 +255,7 @@ export default function LendingListPage() {
 
   const openShipmentModal = (orderId: string, order?: ApiOrder) => {
     setSelectedOrderId(orderId);
-    setCarrier(order?.shippingOutTrackingNumber ? order.shippingMethod?.toUpperCase() || "AUSPOST" : "AUSPOST");
+    setCarrier(order?.shippingOutCarrier || "AUSPOST");
     setTrackingNumber(order?.shippingOutTrackingNumber || "");
     setShipModalOpen(true);
   };

--- a/frontendNext/app/shipping/page.tsx
+++ b/frontendNext/app/shipping/page.tsx
@@ -5,16 +5,24 @@ import { useRouter } from "next/navigation";
 import { Package, Truck, CheckCircle } from "lucide-react";
 import Card from "@/app/components/ui/Card";
 import { getCurrentUser, isAuthenticated } from "@/utils/auth";
-import { getUserAuspostTrackingNumbers, type TrackingNumberItem } from "@/utils/shipping";
+import { getUserShipments, type TrackingNumberItem } from "@/utils/shipping";
 import clsx from "clsx";
 
 const formatDateTime = (value?: string | null) =>
   value ? new Date(value).toLocaleString("en-AU") : "—";
 
+const trackingHref = (item: TrackingNumberItem): string | null => {
+  if (!item.tracking_number) return null;
+  if ((item.carrier || "").toUpperCase() === "AUSPOST") {
+    return `https://auspost.com.au/mypost/track/details/${item.tracking_number}`;
+  }
+  return null;
+};
+
 const ShippingPage: React.FC = () => {
   const router = useRouter();
   const [currentUser, setCurrentUser] = useState<any>(null);
-  const [trackingNumbers, setTrackingNumbers] = useState<TrackingNumberItem[]>([]);
+  const [shipments, setShipments] = useState<TrackingNumberItem[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [activeTab, setActiveTab] = useState<"sent" | "received">("sent");
 
@@ -29,8 +37,8 @@ const ShippingPage: React.FC = () => {
         const userData = await getCurrentUser();
         if (userData) {
           setCurrentUser(userData);
-          const trackingData = await getUserAuspostTrackingNumbers();
-          setTrackingNumbers(trackingData);
+          const data = await getUserShipments();
+          setShipments(data);
         } else {
           router.push("/auth");
         }
@@ -52,12 +60,8 @@ const ShippingPage: React.FC = () => {
     );
   }
 
-  const sentList = trackingNumbers.filter(
-    (t) => !!t.shipping_out_tracking_number
-  );
-  const receivedList = trackingNumbers.filter(
-    (t) => !!t.shipping_return_tracking_number
-  );
+  const sentList = shipments.filter((s) => s.role === "sender");
+  const receivedList = shipments.filter((s) => s.role === "recipient");
   const currentList = activeTab === "sent" ? sentList : receivedList;
 
   return (
@@ -74,7 +78,7 @@ const ShippingPage: React.FC = () => {
               <Package className="w-8 h-8 text-blue-600 mr-3" />
               <div>
                 <p className="text-sm font-medium text-gray-600">Total Shipments</p>
-                <p className="text-2xl font-bold text-gray-900">{trackingNumbers.length}</p>
+                <p className="text-2xl font-bold text-gray-900">{shipments.length}</p>
               </div>
             </div>
           </Card>
@@ -136,66 +140,79 @@ const ShippingPage: React.FC = () => {
             </div>
           ) : (
             <div className="space-y-4">
-              {currentList.map((item) => (
-                <Card key={item.order_id} className="border border-gray-200 shadow-sm">
-                  <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-                    <div className="min-w-0 text-sm text-gray-700">
-                      <h3
-                        className="font-semibold text-black hover:underline cursor-pointer text-base sm:text-lg"
-                        onClick={() => router.push(`/borrowing/${item.order_id}`)}
-                      >
-                        {item.book_title || `Order #${item.order_id}`}
-                      </h3>
+              {currentList.map((item) => {
+                const isDelivered = item.tracking_state === "delivered";
+                const href = trackingHref(item);
+                const legLabel = item.leg === "out" ? "Outgoing" : "Return";
+                const dateLabel = isDelivered ? "Delivered" : "Shipped";
+                const dateValue = isDelivered
+                  ? item.delivered_at || item.updated_at || item.created_at
+                  : item.shipped_at || item.updated_at || item.created_at;
 
-                      {item.counterpart_name && (
-                        <p className="mt-1 text-gray-600">
-                          {item.counterpart_role || "User"}: {item.counterpart_name}
-                        </p>
-                      )}
-
-                      {activeTab === "sent" && item.shipping_out_tracking_number && (
-                        <p className="mt-2">
-                          Outgoing Tracking:{" "}
-                          <a
-                            href={`https://auspost.com.au/mypost/track/details/${item.shipping_out_tracking_number}`}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="font-mono text-blue-600 underline hover:text-blue-800"
+                return (
+                  <Card
+                    key={`${item.order_id}-${item.leg}`}
+                    className="border border-gray-200 shadow-sm"
+                  >
+                    <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                      <div className="min-w-0 text-sm text-gray-700">
+                        <div className="flex flex-wrap items-center gap-2">
+                          <h3
+                            className="font-semibold text-black hover:underline cursor-pointer text-base sm:text-lg"
+                            onClick={() => router.push(`/borrowing/${item.order_id}`)}
                           >
-                            {item.shipping_out_tracking_number}
-                          </a>
-                        </p>
-                      )}
-
-                      {activeTab === "received" && item.shipping_return_tracking_number && (
-                        <p className="mt-2">
-                          Return Tracking:{" "}
-                          <a
-                            href={`https://auspost.com.au/mypost/track/details/${item.shipping_return_tracking_number}`}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="font-mono text-green-600 underline hover:text-green-800"
+                            {item.book_title || `Order #${item.order_id}`}
+                          </h3>
+                          <span
+                            className={clsx(
+                              "inline-block rounded-full px-2 py-0.5 text-xs font-medium",
+                              isDelivered
+                                ? "bg-green-100 text-green-700"
+                                : "bg-orange-100 text-orange-700"
+                            )}
                           >
-                            {item.shipping_return_tracking_number}
-                          </a>
-                        </p>
-                      )}
-                    </div>
+                            {isDelivered ? "Delivered" : "In Transit"}
+                          </span>
+                        </div>
 
-                    <div className="shrink-0 text-xs text-gray-500 sm:text-right">
-                      <p>
-                        {activeTab === "sent" ? "Shipped Date" : "Received Date"}:{" "}
-                        {formatDateTime(
-                          activeTab === "sent"
-                            ? item.updated_at || item.start_at || item.created_at
-                            : item.returned_at || item.updated_at || item.created_at
+                        {item.counterpart_name && (
+                          <p className="mt-1 text-gray-600">
+                            {item.counterpart_role || "User"}: {item.counterpart_name}
+                          </p>
                         )}
-                      </p>
-                      <p className="mt-1 text-gray-400">Order ID: {item.order_id}</p>
+
+                        {item.tracking_number && (
+                          <p className="mt-2">
+                            {legLabel} Tracking
+                            {item.carrier ? ` (${item.carrier})` : ""}:{" "}
+                            {href ? (
+                              <a
+                                href={href}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="font-mono text-blue-600 underline hover:text-blue-800"
+                              >
+                                {item.tracking_number}
+                              </a>
+                            ) : (
+                              <span className="font-mono text-gray-800">
+                                {item.tracking_number}
+                              </span>
+                            )}
+                          </p>
+                        )}
+                      </div>
+
+                      <div className="shrink-0 text-xs text-gray-500 sm:text-right">
+                        <p>
+                          {dateLabel}: {formatDateTime(dateValue)}
+                        </p>
+                        <p className="mt-1 text-gray-400">Order ID: {item.order_id}</p>
+                      </div>
                     </div>
-                  </div>
-                </Card>
-              ))}
+                  </Card>
+                );
+              })}
             </div>
           )}
         </Card>

--- a/frontendNext/app/types/order.ts
+++ b/frontendNext/app/types/order.ts
@@ -104,8 +104,10 @@ export interface ApiOrder {
   returnedAt: string | null;
   completedAt: string | null;
   canceledAt: string | null;
+  shippingOutCarrier: string | null;
   shippingOutTrackingNumber: string | null;
   shippingOutTrackingUrl: string | null;
+  shippingReturnCarrier: string | null;
   shippingReturnTrackingNumber: string | null;
   shippingReturnTrackingUrl: string | null;
   lateFeeAmount: number;

--- a/frontendNext/utils/shipping.ts
+++ b/frontendNext/utils/shipping.ts
@@ -55,23 +55,35 @@ export async function getShippingQuotes(
 }
 
 
+export type ShipmentLeg = "out" | "return";
+export type ShipmentRole = "sender" | "recipient";
+export type TrackingState = "in_transit" | "delivered";
+
 export type TrackingNumberItem = {
   order_id: string;
-  shipping_out_tracking_number?: string | null;
-  shipping_return_tracking_number?: string | null;
+  leg: ShipmentLeg;
+  role: ShipmentRole;
+  tracking_state: TrackingState;
+  carrier?: string | null;
+  tracking_number?: string | null;
   book_title?: string | null;
   counterpart_name?: string | null;
   counterpart_role?: string | null;
   created_at?: string | null;
   updated_at?: string | null;
-  start_at?: string | null;
-  returned_at?: string | null;
+  shipped_at?: string | null;
+  delivered_at?: string | null;
 };
 
 /**
- * @param userId option，Only administrators can upload
+ * Fetch the current user's shipments (both outbound and return legs across all
+ * orders they participate in). Each item is a single shipment leg labelled
+ * with whether the user is the sender or recipient and whether the package
+ * is in transit or already delivered.
+ *
+ * @param userId optional — admin-only override to query another user's shipments.
  */
-export async function getUserAuspostTrackingNumbers(
+export async function getUserShipments(
   userId?: string
 ): Promise<TrackingNumberItem[]> {
   try {
@@ -85,7 +97,7 @@ export async function getUserAuspostTrackingNumbers(
 
     return res.data;
   } catch (err) {
-    console.error("Failed to fetch tracking numbers:", err);
+    console.error("Failed to fetch shipments:", err);
     throw err;
   }
 }


### PR DESCRIPTION
## Summary

Fixes three bugs in the shipping flow that all surfaced from the same order: the lender ships, but the borrower has no clear path to confirm receipt, the `/shipping` page reports zero, and reopening the order asks the lender to retype the tracking number.

### Bug 1 — Shipping page always shows 0
`GET /api/v1/orders/tracking` only returned orders whose carrier was `AUSPOST` and only returned one row per order, so the page (which counts list length) had no way to distinguish *Sent Out* from *Received*. Carrier-Other shipments were silently dropped.

**Fix:** rewrote the endpoint to emit **one entry per shipment leg** (`out` / `return`) with two new fields:
- `role`: `sender` / `recipient`, relative to the requesting user
- `tracking_state`: `in_transit` / `delivered`

`/shipping` now counts/groups by `role` and shows a per-card status badge. The AUSPOST-only filter is gone.

### Bug 2 — Reopening the order forces lender to retype the tracking number
The Ship modal's `trackingNumber` / `carrier` state initialized to empty on every mount and there was no `useEffect` to hydrate it from the saved order. Lending page had a related bug (it was reading `shippingMethod`, which is `post`/`pickup`, as the courier name).

**Fix:**
- Backend: `Order.to_dict()` now exposes `shippingOutCarrier` / `shippingReturnCarrier`
- Frontend: borrowing detail page hydrates the modal from the saved values, picking the right leg based on order status; lending page reads `shippingOutCarrier` instead of `shippingMethod`

### Bug 3 — Borrower has no obvious way to confirm receipt
The Confirm Receive button existed but lived deep in the Actions section and was never advertised. Orders could sit in `PENDING_SHIPMENT` indefinitely.

**Fix:** added an info banner near the top of the borrower's order detail page when the lender has filled a tracking number, with a Confirm Receive CTA that opens the existing modal.

## API contract change

`GET /api/v1/orders/tracking` response shape changed (see `schemas/order.py::TrackingNumberItem`). Old fields `shipping_out_tracking_number` / `shipping_return_tracking_number` / `start_at` / `returned_at` are gone; new fields are `leg`, `role`, `tracking_state`, `carrier`, `tracking_number`, `shipped_at`, `delivered_at`. Only frontend caller (`shipping/page.tsx`) was updated in this PR.

## Test plan

- [ ] Lender fills tracking on a `PENDING_SHIPMENT` order, reopens detail page, opens Update Shipping modal — tracking number and carrier are prefilled
- [ ] Same lender's `/shipping` page: Sent Out count is 1, card shows orange **In Transit** badge
- [ ] Borrower's `/shipping` page: Received count is 1, same card with **In Transit** badge
- [ ] Borrower's order detail page: blue banner with Confirm Receive CTA visible
- [ ] Borrower clicks Confirm Receive → both users' `/shipping` cards flip to green **Delivered** badge; counts unchanged
- [ ] Carrier=Other shipments still appear on the page (previously dropped)