### PR TITLE
Fix 502 error

### DIFF
--- a/fastapi/models/deposit_audit_log.py
+++ b/fastapi/models/deposit_audit_log.py
@@ -27,7 +27,6 @@ AUDIT_SEVERITY_ENUM = ("none", "light", "medium", "severe")
 
 class DepositAuditLog(Base):
     __tablename__ = "deposit_audit_log"
-    __table_args__ = {"mysql_charset": "utf8mb4", "mysql_collate": "utf8mb4_unicode_ci"}
 
     id = Column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
     order_id = Column(String(36), ForeignKey("orders.id", ondelete="SET NULL"),

--- a/fastapi/models/deposit_evidence.py
+++ b/fastapi/models/deposit_evidence.py
@@ -19,7 +19,6 @@ EVIDENCE_SEVERITY_ENUM = ("light", "medium", "severe")
 
 class DepositEvidence(Base):
     __tablename__ = "deposit_evidence"
-    __table_args__ = {"mysql_charset": "utf8mb4", "mysql_collate": "utf8mb4_unicode_ci"}
 
     id = Column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
     order_id = Column(String(36), ForeignKey("orders.id", ondelete="CASCADE"),


### PR DESCRIPTION
Remove explicit __table_args__ containing mysql_charset and mysql_collate from DepositAuditLog and DepositEvidence models. This removes MySQL-specific table options from fastapi/models/deposit_audit_log.py and fastapi/models/deposit_evidence.py so charset/collation is handled by DB defaults or migrations instead of model definitions.