### PR TITLE
VPS04: Align compose deployment with BookBorrow

### DIFF
--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -1,11 +1,10 @@
-version: "3.9"
 services:
   db:             # Local MySQL database for development only;
     image: mysql:8.0
     container_name: mysql-db
     environment:
       MYSQL_ROOT_PASSWORD: rootpassword
-      MYSQL_DATABASE: BookHive
+      MYSQL_DATABASE: BookBorrow
       MYSQL_USER: myuser
       MYSQL_PASSWORD: "123456"
     ports:
@@ -40,7 +39,13 @@ services:
 
   frontend:
     image: frontendnext:latest
-    build: ./frontendNext
+    build:
+      context: ./frontendNext
+      args:
+        NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL}
+        NEXT_PUBLIC_WS_URL: ${NEXT_PUBLIC_WS_URL}
+        NEXT_PUBLIC_STRIPE_PK: ${NEXT_PUBLIC_STRIPE_PK}
+        NEXT_PUBLIC_STRIPE_TEST_DESTINATION_ACCOUNT_ID: ${NEXT_PUBLIC_STRIPE_TEST_DESTINATION_ACCOUNT_ID}
     container_name: next-frontend
     env_file:
       - ./.env

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,4 +1,4 @@
-version: "3.9"
+name: bookborrow
 
 services:
   db:
@@ -8,7 +8,7 @@ services:
       - "3307:3306"
     environment:
       MYSQL_ROOT_PASSWORD: rootpassword
-      MYSQL_DATABASE: BookHive
+      MYSQL_DATABASE: BookBorrow
       MYSQL_USER: myuser
       MYSQL_PASSWORD: "123456"
     volumes:
@@ -31,7 +31,13 @@ services:
 
   frontend:
     image: frontendnext:latest
-    build: ./frontendNext             # Path to frontend Dockerfile
+    build:
+      context: ./frontendNext             # Path to frontend Dockerfile
+      args:
+        NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL}
+        NEXT_PUBLIC_WS_URL: ${NEXT_PUBLIC_WS_URL}
+        NEXT_PUBLIC_STRIPE_PK: ${NEXT_PUBLIC_STRIPE_PK}
+        NEXT_PUBLIC_STRIPE_TEST_DESTINATION_ACCOUNT_ID: ${NEXT_PUBLIC_STRIPE_TEST_DESTINATION_ACCOUNT_ID}
     container_name: next-frontend
     ports:
       - "3000:3000"          # Host:Container
@@ -64,6 +70,7 @@ services:
 
 volumes:
   mysql_data:
+    name: bookborrow_mysql_data
 
 networks:
   mynetwork:

--- a/fastapi/models/deposit_audit_log.py
+++ b/fastapi/models/deposit_audit_log.py
@@ -27,7 +27,6 @@ AUDIT_SEVERITY_ENUM = ("none", "light", "medium", "severe")
 
 class DepositAuditLog(Base):
     __tablename__ = "deposit_audit_log"
-    __table_args__ = {"mysql_charset": "utf8mb4", "mysql_collate": "utf8mb4_unicode_ci"}
 
     id = Column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
     order_id = Column(String(36), ForeignKey("orders.id", ondelete="SET NULL"),

--- a/fastapi/models/deposit_evidence.py
+++ b/fastapi/models/deposit_evidence.py
@@ -19,7 +19,6 @@ EVIDENCE_SEVERITY_ENUM = ("light", "medium", "severe")
 
 class DepositEvidence(Base):
     __tablename__ = "deposit_evidence"
-    __table_args__ = {"mysql_charset": "utf8mb4", "mysql_collate": "utf8mb4_unicode_ci"}
 
     id = Column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
     order_id = Column(String(36), ForeignKey("orders.id", ondelete="CASCADE"),


### PR DESCRIPTION
## Summary
- rename Docker Compose project and MySQL defaults from BookHive to BookBorrow
- pin the production MySQL volume to bookborrow_mysql_data
- pass NEXT_PUBLIC build args into frontend Docker builds
- remove obsolete Compose version declarations
- allow fresh MySQL 8 BookBorrow databases to initialize deposit tables without collation-related FK failures

## Verification
- docker compose config --services
- docker compose -f compose.yaml -f compose.dev.yaml config --services
- docker compose -f compose.yaml -f compose.dev.yaml down -v
- docker compose -f compose.yaml -f compose.dev.yaml up --build -d
- local checks: frontend root 200, backend /health 200, nginx /api/v1/books 200, BookBorrow has 25 tables
- verified on VPS before PR: home/API/backend health returned 200