### PR TITLE
VPS05: Harden post-deployment operations

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,8 +3,8 @@ name: Deploy to VPS
 on:
   push:
     branches:
-      - "master"
-      - "infra/github-actions-deploy"
+      - VPSdeployment
+  workflow_dispatch:
 
 concurrency:
   group: deploy-to-vps
@@ -12,43 +12,26 @@ concurrency:
 
 jobs:
   deploy-prod:
-    if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: webfactory/ssh-agent@v0.7.0
+      - uses: actions/checkout@v4
+
+      - uses: webfactory/ssh-agent@v0.9.0
         with:
           ssh-private-key: ${{ secrets.VPS_SSH_KEY }}
-      - name: Deploy to Production
+
+      - name: Deploy BookBorrow to production
         run: |
-          ssh -o StrictHostKeyChecking=no ${{ secrets.VPS_USER }}@${{ secrets.VPS_HOST }} << 'EOF'
-            cd ~/capstone15/Bookhive
-            git pull origin master
-            docker compose down
-            docker compose up -d --build
-            docker compose ps
+          ssh -o StrictHostKeyChecking=no "${{ secrets.VPS_USER }}@${{ secrets.VPS_HOST }}" << 'EOF'
+            set -euo pipefail
+            cd /root/capstone15/Bookborrow
+            git fetch origin
+            git pull --ff-only origin VPSdeployment
+            docker compose -f compose.yaml build
+            docker compose -f compose.yaml up -d
+            docker compose -f compose.yaml exec -T backend alembic -c alembic.ini upgrade head
+            bash scripts/vps/check_health.sh
+            docker compose -f compose.yaml ps
             git log -1 --oneline
-            echo "🚀 Deployment complete!"
+            echo "Deployment complete"
           EOF
-
-  deploy-staging:
-    if: github.ref == 'refs/heads/infra/github-actions-deploy'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: webfactory/ssh-agent@v0.7.0
-        with:
-          ssh-private-key: ${{ secrets.VPS_SSH_KEY }}
-      - name: Deploy to Staging
-        run: |
-          ssh -o StrictHostKeyChecking=no ${{ secrets.VPS_USER }}@${{ secrets.VPS_HOST }} << 'EOF'
-            cd ~/capstone15/Bookhive
-            git pull origin infra/github-actions-deploy
-            docker compose down
-            docker compose up -d --build
-            docker compose ps
-            git log -1 --oneline
-            echo "🚀 Deployment complete!"
-          EOF
-
-

--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,8 @@ coverage.xml
 local_settings.py
 db.sqlite3
 *.sql
+*.sql.gz
+backups/
 
 
 # Flask stuff:

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,18 @@ build: ## Build production containers
 logs: ## Show logs (prod)
 	docker compose -f compose.yaml logs -f nginx frontend backend
 
+migrate: ## Run database migrations in the backend container
+	docker compose -f compose.yaml exec backend alembic -c alembic.ini upgrade head
+
+health: ## Run production health checks
+	bash scripts/vps/check_health.sh
+
+backup-db: ## Create a Docker MySQL database backup
+	bash scripts/vps/backup_db.sh
+
+rollback: ## Roll back to a git ref and rebuild production containers (usage: make rollback REF=<ref>)
+	bash scripts/vps/rollback.sh $(REF)
+
 
 # =====================
 # Development (Local)
@@ -28,6 +40,9 @@ build-dev: ## Build development containers
 
 logs-dev: ## Show logs (dev)
 	docker compose -f compose.yaml -f compose.dev.yaml logs -f nginx frontend backend
+
+migrate-dev: ## Run database migrations in the dev backend container
+	docker compose -f compose.yaml -f compose.dev.yaml exec backend alembic -c alembic.ini upgrade head
 
 
 # =====================

--- a/README.md
+++ b/README.md
@@ -353,6 +353,8 @@ brew install make
 - TLS certificates (`nginx/letsencrypt/`) and VPS runtime artifacts must not be pushed.
 - Local development does not require HTTPS.
 - Do not push code from production servers. Production changes must flow through GitHub-based workflows to preserve traceability and deployment consistency.
+- Production verification, monitoring, backup, restore, and rollback steps are documented in [docs/production-runbook.md](docs/production-runbook.md).
+- Database schema changes are tracked by Alembic migrations under `fastapi/migrations/`.
 
 ---
 
@@ -365,6 +367,9 @@ make up
 make down
 make build
 make logs
+make migrate
+make health
+make backup-db
 ```
 
 ### Development
@@ -374,6 +379,7 @@ make up-dev
 make down-dev
 make build-dev
 make logs-dev
+make migrate-dev
 ```
 
 ### Cleanup

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -1,11 +1,10 @@
-version: "3.9"
 services:
   db:             # Local MySQL database for development only;
     image: mysql:8.0
     container_name: mysql-db
     environment:
       MYSQL_ROOT_PASSWORD: rootpassword
-      MYSQL_DATABASE: BookHive
+      MYSQL_DATABASE: BookBorrow
       MYSQL_USER: myuser
       MYSQL_PASSWORD: "123456"
     ports:
@@ -40,7 +39,13 @@ services:
 
   frontend:
     image: frontendnext:latest
-    build: ./frontendNext
+    build:
+      context: ./frontendNext
+      args:
+        NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL}
+        NEXT_PUBLIC_WS_URL: ${NEXT_PUBLIC_WS_URL}
+        NEXT_PUBLIC_STRIPE_PK: ${NEXT_PUBLIC_STRIPE_PK}
+        NEXT_PUBLIC_STRIPE_TEST_DESTINATION_ACCOUNT_ID: ${NEXT_PUBLIC_STRIPE_TEST_DESTINATION_ACCOUNT_ID}
     container_name: next-frontend
     env_file:
       - ./.env

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,4 +1,4 @@
-version: "3.9"
+name: bookborrow
 
 services:
   db:
@@ -8,7 +8,7 @@ services:
       - "3307:3306"
     environment:
       MYSQL_ROOT_PASSWORD: rootpassword
-      MYSQL_DATABASE: BookHive
+      MYSQL_DATABASE: BookBorrow
       MYSQL_USER: myuser
       MYSQL_PASSWORD: "123456"
     volumes:
@@ -31,7 +31,13 @@ services:
 
   frontend:
     image: frontendnext:latest
-    build: ./frontendNext             # Path to frontend Dockerfile
+    build:
+      context: ./frontendNext             # Path to frontend Dockerfile
+      args:
+        NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL}
+        NEXT_PUBLIC_WS_URL: ${NEXT_PUBLIC_WS_URL}
+        NEXT_PUBLIC_STRIPE_PK: ${NEXT_PUBLIC_STRIPE_PK}
+        NEXT_PUBLIC_STRIPE_TEST_DESTINATION_ACCOUNT_ID: ${NEXT_PUBLIC_STRIPE_TEST_DESTINATION_ACCOUNT_ID}
     container_name: next-frontend
     ports:
       - "3000:3000"          # Host:Container
@@ -64,6 +70,7 @@ services:
 
 volumes:
   mysql_data:
+    name: bookborrow_mysql_data
 
 networks:
   mynetwork:

--- a/docs/production-runbook.md
+++ b/docs/production-runbook.md
@@ -1,0 +1,144 @@
+# Production Verification Runbook
+
+This runbook covers the BookBorrow VPS deployment after the Phase 2
+BookHive-to-BookBorrow migration.
+
+## Source of Truth
+
+- Repository: `https://github.com/zyxasd707/CITS5206-Book-Borrow-Peer-to-Peer-Book-Lending-Platform-Second-Phase.git`
+- Deployment branch: `VPSdeployment`
+- VPS app directory: `/root/capstone15/Bookborrow`
+- Public URL: `https://www.bookborrow.org`
+- Database: Docker MySQL container `mysql-db`, database `BookBorrow`
+- Database volume: `bookborrow_mysql_data`
+
+## Standard Deployment
+
+```bash
+cd /root/capstone15/Bookborrow
+git fetch origin
+git pull --ff-only origin VPSdeployment
+docker compose -f compose.yaml build
+docker compose -f compose.yaml up -d
+docker compose -f compose.yaml exec backend alembic -c alembic.ini upgrade head
+docker compose -f compose.yaml ps
+```
+
+Run migrations after the containers are healthy and before accepting traffic
+for schema-dependent changes.
+
+## Production Smoke Checks
+
+```bash
+curl -k -I https://www.bookborrow.org
+curl -k -i https://www.bookborrow.org/api/v1/books
+curl -i http://127.0.0.1:8000/health
+docker compose -f compose.yaml ps
+docker logs --tail=120 fastapi-backend
+```
+
+Expected results:
+
+- Frontend returns `200`.
+- `/api/v1/books` returns `200` with JSON.
+- Backend `/health` returns `{"status":"healthy"}`.
+- `mysql-db`, `fastapi-backend`, `next-frontend`, and `nginx-proxy` are running.
+
+## Email Flow Check
+
+1. Open `https://www.bookborrow.org/register`.
+2. Request an email verification code using a controlled test address.
+3. Confirm the email arrives from the configured Brevo sender.
+4. Check backend logs if delivery fails:
+
+```bash
+docker logs --tail=200 fastapi-backend
+```
+
+## Payment Flow Check
+
+Use Stripe test keys only in non-production payment tests.
+
+1. Register or log in as a borrower.
+2. Add a listed book to cart.
+3. Complete checkout with a Stripe test card.
+4. Verify the order appears under borrowing/lending views.
+5. Verify payment/refund records through admin refund pages if applicable.
+
+## Monitoring Checks
+
+Run the baseline check script:
+
+```bash
+cd /root/capstone15/Bookborrow
+bash scripts/vps/check_health.sh
+```
+
+The script checks:
+
+- container presence and restart counts
+- backend health
+- public frontend/API routes
+- disk usage
+- TLS certificate expiry
+
+Schedule it with cron or an external monitor and alert on non-zero exit.
+
+Example cron entry:
+
+```cron
+*/15 * * * * cd /root/capstone15/Bookborrow && bash scripts/vps/check_health.sh >> /var/log/bookborrow-health.log 2>&1
+```
+
+## Backups
+
+Manual backup:
+
+```bash
+cd /root/capstone15/Bookborrow
+bash scripts/vps/backup_db.sh
+```
+
+Recommended daily cron:
+
+```cron
+15 18 * * * cd /root/capstone15/Bookborrow && bash scripts/vps/backup_db.sh >> /var/log/bookborrow-backup.log 2>&1
+```
+
+The default backup directory is:
+
+```text
+/root/capstone15/backups/bookborrow-db
+```
+
+## Restore Drill
+
+Use a non-production database or a temporary VPS snapshot when possible.
+
+```bash
+cd /root/capstone15/Bookborrow
+bash scripts/vps/restore_db.sh /root/capstone15/backups/bookborrow-db/<backup-file>.sql.gz
+docker compose -f compose.yaml restart backend
+curl -k -i https://www.bookborrow.org/api/v1/books
+```
+
+Record the date, backup file, operator, and outcome in the team handover notes.
+
+## Rollback
+
+Rollback to a known good Git ref:
+
+```bash
+cd /root/capstone15/Bookborrow
+bash scripts/vps/rollback.sh <git-ref>
+```
+
+If the rollback also requires data rollback, restore a database backup before
+reopening the service to users.
+
+## Do Not Commit
+
+- `.env`
+- `nginx/letsencrypt/`
+- `nginx/certbot/`
+- database backup files

--- a/fastapi/alembic.ini
+++ b/fastapi/alembic.ini
@@ -1,0 +1,40 @@
+[alembic]
+script_location = migrations
+prepend_sys_path = .
+path_separator = os
+
+sqlalchemy.url = driver://user:pass@localhost/dbname
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARNING
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARNING
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/fastapi/main.py
+++ b/fastapi/main.py
@@ -42,122 +42,6 @@ from models.checkout import Base as CheckoutBase
 from models.service_fee import Base as ServiceFeeBase
 
 
-def ensure_book_deposit_income_percentage_column() -> None:
-    with engine.begin() as conn:
-        column_exists = conn.execute(
-            text("SHOW COLUMNS FROM book LIKE 'deposit_income_percentage'")
-        ).first()
-        if column_exists:
-            return
-        conn.execute(
-            text(
-                "ALTER TABLE book ADD COLUMN deposit_income_percentage INTEGER NOT NULL DEFAULT 0"
-            )
-        )
-        print("Added missing book.deposit_income_percentage column")
-
-
-def ensure_checkout_owner_income_amount_column() -> None:
-    with engine.begin() as conn:
-        column_exists = conn.execute(
-            text("SHOW COLUMNS FROM checkout LIKE 'owner_income_amount'")
-        ).first()
-        if column_exists:
-            return
-        conn.execute(
-            text(
-                "ALTER TABLE checkout ADD COLUMN owner_income_amount DECIMAL(10, 2) NOT NULL DEFAULT 0.00"
-            )
-        )
-        print("Added missing checkout.owner_income_amount column")
-
-
-def ensure_order_owner_income_amount_column() -> None:
-    with engine.begin() as conn:
-        column_exists = conn.execute(
-            text("SHOW COLUMNS FROM orders LIKE 'owner_income_amount'")
-        ).first()
-        if column_exists:
-            return
-        conn.execute(
-            text(
-                "ALTER TABLE orders ADD COLUMN owner_income_amount DECIMAL(10, 2) NOT NULL DEFAULT 0.00"
-            )
-        )
-        print("Added missing orders.owner_income_amount column")
-
-
-def ensure_order_deposit_columns() -> None:
-    required_columns = {
-        "deposit_status": (
-            "ALTER TABLE orders ADD COLUMN deposit_status "
-            "ENUM('held','pending_review','released','partially_deducted','forfeited') "
-            "NOT NULL DEFAULT 'held'"
-        ),
-        "deposit_deducted_cents": (
-            "ALTER TABLE orders ADD COLUMN deposit_deducted_cents INTEGER NOT NULL DEFAULT 0"
-        ),
-        "damage_severity_final": (
-            "ALTER TABLE orders ADD COLUMN damage_severity_final "
-            "ENUM('none','light','medium','severe') NULL"
-        ),
-    }
-    with engine.begin() as conn:
-        for column_name, ddl in required_columns.items():
-            column_exists = conn.execute(
-                text(f"SHOW COLUMNS FROM orders LIKE '{column_name}'")
-            ).first()
-            if column_exists:
-                continue
-            conn.execute(text(ddl))
-            print(f"Added missing orders.{column_name} column")
-
-
-def ensure_user_damage_columns() -> None:
-    required_columns = {
-        "damage_strike_count": (
-            "ALTER TABLE users ADD COLUMN damage_strike_count INTEGER NOT NULL DEFAULT 0"
-        ),
-        "damage_severity_score": (
-            "ALTER TABLE users ADD COLUMN damage_severity_score INTEGER NOT NULL DEFAULT 0"
-        ),
-        "is_restricted": (
-            "ALTER TABLE users ADD COLUMN is_restricted BOOLEAN NOT NULL DEFAULT FALSE"
-        ),
-        "restriction_reason": (
-            "ALTER TABLE users ADD COLUMN restriction_reason VARCHAR(255) NULL"
-        ),
-    }
-    with engine.begin() as conn:
-        for column_name, ddl in required_columns.items():
-            column_exists = conn.execute(
-                text(f"SHOW COLUMNS FROM users LIKE '{column_name}'")
-            ).first()
-            if column_exists:
-                continue
-            conn.execute(text(ddl))
-            print(f"Added missing users.{column_name} column")
-
-
-def ensure_payment_columns() -> None:
-    required_columns = {
-        "checkout_id": (
-            "ALTER TABLE payments ADD COLUMN checkout_id VARCHAR(255) NULL UNIQUE AFTER payment_id"
-        ),
-        "purchase": (
-            "ALTER TABLE payments ADD COLUMN purchase INTEGER NOT NULL DEFAULT 0 AFTER status"
-        ),
-    }
-    with engine.begin() as conn:
-        for column_name, ddl in required_columns.items():
-            column_exists = conn.execute(
-                text(f"SHOW COLUMNS FROM payments LIKE '{column_name}'")
-            ).first()
-            if column_exists:
-                continue
-            conn.execute(text(ddl))
-            print(f"Added missing payments.{column_name} column")
-
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     import time
@@ -177,12 +61,6 @@ async def lifespan(app: FastAPI):
     Base.metadata.create_all(bind=engine)
     CheckoutBase.metadata.create_all(bind=engine)
     ServiceFeeBase.metadata.create_all(bind=engine)
-    ensure_book_deposit_income_percentage_column()
-    ensure_checkout_owner_income_amount_column()
-    ensure_order_owner_income_amount_column()
-    ensure_order_deposit_columns()
-    ensure_user_damage_columns()
-    ensure_payment_columns()
     seed_sample_data()
     start_scheduler()
     yield

--- a/fastapi/migrations/env.py
+++ b/fastapi/migrations/env.py
@@ -1,0 +1,46 @@
+from logging.config import fileConfig
+
+from alembic import context
+from sqlalchemy import engine_from_config, pool
+
+from core.config import settings
+
+config = context.config
+config.set_main_option("sqlalchemy.url", settings.DATABASE_URL)
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+target_metadata = None
+
+
+def run_migrations_offline() -> None:
+    context.configure(
+        url=settings.DATABASE_URL,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section, {}),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/fastapi/migrations/script.py.mako
+++ b/fastapi/migrations/script.py.mako
@@ -1,0 +1,24 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+${imports if imports else ""}
+
+revision: str = ${repr(up_revision)}
+down_revision: Union[str, None] = ${repr(down_revision)}
+branch_labels: Union[str, Sequence[str], None] = ${repr(branch_labels)}
+depends_on: Union[str, Sequence[str], None] = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    ${downgrades if downgrades else "pass"}

--- a/fastapi/migrations/versions/20260501_0001_phase2_schema_hardening.py
+++ b/fastapi/migrations/versions/20260501_0001_phase2_schema_hardening.py
@@ -1,0 +1,121 @@
+"""Move Phase 2 runtime schema patches into Alembic.
+
+This migration is intentionally defensive because the VPS database may
+already contain columns that were previously added by application startup.
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+from sqlalchemy import inspect, text
+
+revision: str = "20260501_0001"
+down_revision: Union[str, None] = None
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _table_exists(table_name: str) -> bool:
+    bind = op.get_bind()
+    return inspect(bind).has_table(table_name)
+
+
+def _column_exists(table_name: str, column_name: str) -> bool:
+    if not _table_exists(table_name):
+        return False
+    bind = op.get_bind()
+    columns = inspect(bind).get_columns(table_name)
+    return any(column["name"] == column_name for column in columns)
+
+
+def _execute_if_missing(table_name: str, column_name: str, ddl: str) -> None:
+    if _column_exists(table_name, column_name):
+        return
+    op.execute(text(ddl))
+
+
+def _execute_if_present(table_name: str, column_name: str, ddl: str) -> None:
+    if not _column_exists(table_name, column_name):
+        return
+    op.execute(text(ddl))
+
+
+def upgrade() -> None:
+    _execute_if_missing(
+        "book",
+        "deposit_income_percentage",
+        "ALTER TABLE book ADD COLUMN deposit_income_percentage INTEGER NOT NULL DEFAULT 0",
+    )
+    _execute_if_missing(
+        "checkout",
+        "owner_income_amount",
+        "ALTER TABLE checkout ADD COLUMN owner_income_amount DECIMAL(10, 2) NOT NULL DEFAULT 0.00",
+    )
+    _execute_if_missing(
+        "orders",
+        "owner_income_amount",
+        "ALTER TABLE orders ADD COLUMN owner_income_amount DECIMAL(10, 2) NOT NULL DEFAULT 0.00",
+    )
+    _execute_if_missing(
+        "orders",
+        "deposit_status",
+        "ALTER TABLE orders ADD COLUMN deposit_status "
+        "ENUM('held','pending_review','released','partially_deducted','forfeited') "
+        "NOT NULL DEFAULT 'held'",
+    )
+    _execute_if_missing(
+        "orders",
+        "deposit_deducted_cents",
+        "ALTER TABLE orders ADD COLUMN deposit_deducted_cents INTEGER NOT NULL DEFAULT 0",
+    )
+    _execute_if_missing(
+        "orders",
+        "damage_severity_final",
+        "ALTER TABLE orders ADD COLUMN damage_severity_final "
+        "ENUM('none','light','medium','severe') NULL",
+    )
+    _execute_if_missing(
+        "users",
+        "damage_strike_count",
+        "ALTER TABLE users ADD COLUMN damage_strike_count INTEGER NOT NULL DEFAULT 0",
+    )
+    _execute_if_missing(
+        "users",
+        "damage_severity_score",
+        "ALTER TABLE users ADD COLUMN damage_severity_score INTEGER NOT NULL DEFAULT 0",
+    )
+    _execute_if_missing(
+        "users",
+        "is_restricted",
+        "ALTER TABLE users ADD COLUMN is_restricted BOOLEAN NOT NULL DEFAULT FALSE",
+    )
+    _execute_if_missing(
+        "users",
+        "restriction_reason",
+        "ALTER TABLE users ADD COLUMN restriction_reason VARCHAR(255) NULL",
+    )
+    _execute_if_missing(
+        "payments",
+        "checkout_id",
+        "ALTER TABLE payments ADD COLUMN checkout_id VARCHAR(255) NULL UNIQUE AFTER payment_id",
+    )
+    _execute_if_missing(
+        "payments",
+        "purchase",
+        "ALTER TABLE payments ADD COLUMN purchase INTEGER NOT NULL DEFAULT 0 AFTER status",
+    )
+
+
+def downgrade() -> None:
+    _execute_if_present("payments", "purchase", "ALTER TABLE payments DROP COLUMN purchase")
+    _execute_if_present("payments", "checkout_id", "ALTER TABLE payments DROP COLUMN checkout_id")
+    _execute_if_present("users", "restriction_reason", "ALTER TABLE users DROP COLUMN restriction_reason")
+    _execute_if_present("users", "is_restricted", "ALTER TABLE users DROP COLUMN is_restricted")
+    _execute_if_present("users", "damage_severity_score", "ALTER TABLE users DROP COLUMN damage_severity_score")
+    _execute_if_present("users", "damage_strike_count", "ALTER TABLE users DROP COLUMN damage_strike_count")
+    _execute_if_present("orders", "damage_severity_final", "ALTER TABLE orders DROP COLUMN damage_severity_final")
+    _execute_if_present("orders", "deposit_deducted_cents", "ALTER TABLE orders DROP COLUMN deposit_deducted_cents")
+    _execute_if_present("orders", "deposit_status", "ALTER TABLE orders DROP COLUMN deposit_status")
+    _execute_if_present("orders", "owner_income_amount", "ALTER TABLE orders DROP COLUMN owner_income_amount")
+    _execute_if_present("checkout", "owner_income_amount", "ALTER TABLE checkout DROP COLUMN owner_income_amount")
+    _execute_if_present("book", "deposit_income_percentage", "ALTER TABLE book DROP COLUMN deposit_income_percentage")

--- a/fastapi/models/deposit_audit_log.py
+++ b/fastapi/models/deposit_audit_log.py
@@ -27,7 +27,6 @@ AUDIT_SEVERITY_ENUM = ("none", "light", "medium", "severe")
 
 class DepositAuditLog(Base):
     __tablename__ = "deposit_audit_log"
-    __table_args__ = {"mysql_charset": "utf8mb4", "mysql_collate": "utf8mb4_unicode_ci"}
 
     id = Column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
     order_id = Column(String(36), ForeignKey("orders.id", ondelete="SET NULL"),

--- a/fastapi/models/deposit_evidence.py
+++ b/fastapi/models/deposit_evidence.py
@@ -19,7 +19,6 @@ EVIDENCE_SEVERITY_ENUM = ("light", "medium", "severe")
 
 class DepositEvidence(Base):
     __tablename__ = "deposit_evidence"
-    __table_args__ = {"mysql_charset": "utf8mb4", "mysql_collate": "utf8mb4_unicode_ci"}
 
     id = Column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
     order_id = Column(String(36), ForeignKey("orders.id", ondelete="CASCADE"),

--- a/fastapi/requirements.txt
+++ b/fastapi/requirements.txt
@@ -2,7 +2,7 @@ fastapi==0.135.2
 uvicorn[standard]==0.42.0
 python-jose[cryptography]==3.5.0
 passlib==1.7.4
-bcrypt==4.3.0
+bcrypt==4.0.1
 python-multipart==0.0.22
 sqlalchemy==2.0.48
 python-dotenv==1.2.2
@@ -17,3 +17,4 @@ fastapi-mail==1.6.2
 pillow==12.1.1
 APScheduler==3.11.2
 tzlocal==5.3.1
+alembic==1.17.2

--- a/fastapi/seed.py
+++ b/fastapi/seed.py
@@ -466,14 +466,6 @@ def seed(*, force: bool = False):
     db = SessionLocal()
     try:
         if not force and not is_database_empty(db):
-            print("Database is not empty. Skipping auto-seed.")
-            # Still try the deposit demo — it's idempotent and a small addition
-            # for dev DBs that predate MVP6-1.
-            try:
-                _seed_deposit_demos(db)
-            except Exception as exc:
-                db.rollback()
-                print(f"  Deposit demo seed failed: {exc}")
             return
 
         print("Seeding users...")

--- a/frontendNext/app/checkout/page.tsx
+++ b/frontendNext/app/checkout/page.tsx
@@ -74,11 +74,14 @@ function SummaryLabel({ label, tooltip }: { label: string; tooltip?: string }) {
   return (
     <span className="flex items-center gap-1.5">
       <span>{label}</span>
-        <span className="group relative inline-flex items-center">
+        <span
+          className="group relative inline-flex items-center"
+          aria-label={tooltip}
+          title={tooltip}
+        >
           <CircleHelp
             className="h-4 w-4 cursor-help text-gray-400"
-            aria-label={tooltip}
-            title={tooltip}
+            aria-hidden="true"
           />
         <span className="pointer-events-none absolute left-0 top-full z-10 mt-2 w-56 rounded-md bg-gray-900 px-3 py-2 text-xs font-normal leading-5 text-white opacity-0 shadow-lg transition-opacity duration-150 group-hover:opacity-100 group-focus-within:opacity-100">
           {tooltip}

--- a/frontendNext/app/complain/page.tsx
+++ b/frontendNext/app/complain/page.tsx
@@ -27,6 +27,25 @@ import { getOrderById } from "@/utils/borrowingOrders";
 import { createPaymentDispute } from "@/utils/payments";
 import { uploadFile } from "@/utils/books";
 
+type ComplaintFormState = {
+  type: CreateComplaintRequest["type"];
+  subject: string;
+  description: string;
+  orderId: string;
+  respondentId: string;
+  damageSeverity: "none" | "light" | "medium" | "severe";
+  needsRefund: boolean;
+};
+
+const initialComplaintForm: ComplaintFormState = {
+  type: "other",
+  subject: "",
+  description: "",
+  orderId: "",
+  respondentId: "",
+  damageSeverity: "none",
+  needsRefund: false,
+};
 
 const ComplainPage: React.FC = () => {
   const router = useRouter();
@@ -35,15 +54,7 @@ const ComplainPage: React.FC = () => {
   const [complaints, setComplaints] = useState<Complaint[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
-  const [newComplaint, setNewComplaint] = useState({
-    type: "other" as const,
-    subject: "",
-    description: "",
-    orderId: "",
-    respondentId: "",
-    damageSeverity: "none" as const,
-    needsRefund: false
-  });
+  const [newComplaint, setNewComplaint] = useState<ComplaintFormState>(initialComplaintForm);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [userCache, setUserCache] = useState<Record<string, User>>({});
   const [searchQuery, setSearchQuery] = useState("");
@@ -247,7 +258,7 @@ const ComplainPage: React.FC = () => {
       setComplaints([createdComplaint, ...complaints]);
     }
     setIsCreateModalOpen(false);
-    setNewComplaint({ type: "other", subject: "", description: "", orderId: "", respondentId: "", damageSeverity: "none", needsRefund: false });
+    setNewComplaint(initialComplaintForm);
     setEvidenceFiles([]);
 
     console.log("Complaint flow completed successfully.");
@@ -665,7 +676,7 @@ const ComplainPage: React.FC = () => {
                   variant="outline"
                   onClick={() => {
                     setIsCreateModalOpen(false);
-                    setNewComplaint({ type: "other", subject: "", description: "", orderId: "", respondentId: "", damageSeverity: "none", needsRefund: false });
+                    setNewComplaint(initialComplaintForm);
                     setEvidenceFiles([]);
                   }}
                   disabled={isSubmitting}

--- a/frontendNext/app/lending/add/page.tsx
+++ b/frontendNext/app/lending/add/page.tsx
@@ -552,11 +552,14 @@ export default function AddBook() {
                         label={
                           <span className="flex items-center gap-1.5">
                             <span>Deposit Fee*</span>
-                            <span className="group relative inline-flex items-center">
+                            <span
+                              className="group relative inline-flex items-center"
+                              aria-label={depositTooltipText}
+                              title={depositTooltipText}
+                            >
                               <CircleHelp
                                 className="h-4 w-4 cursor-help text-gray-400"
-                                aria-label={depositTooltipText}
-                                title={depositTooltipText}
+                                aria-hidden="true"
                               />
                               <span className="pointer-events-none absolute left-1/2 top-full z-10 mt-2 w-64 -translate-x-1/2 rounded-md bg-gray-900 px-3 py-2 text-xs font-normal leading-5 text-white opacity-0 shadow-lg transition-opacity duration-150 group-hover:opacity-100 group-focus-within:opacity-100">
                                 {depositTooltipText}
@@ -574,11 +577,14 @@ export default function AddBook() {
                         <label className="block text-sm font-medium text-gray-700 mb-2">
                           <span className="flex items-center gap-1.5">
                             <span>Rental/Day*</span>
-                            <span className="group relative inline-flex items-center">
+                            <span
+                              className="group relative inline-flex items-center"
+                              aria-label={rentalPerDayTooltipText}
+                              title={rentalPerDayTooltipText}
+                            >
                               <CircleHelp
                                 className="h-4 w-4 cursor-help text-gray-400"
-                                aria-label={rentalPerDayTooltipText}
-                                title={rentalPerDayTooltipText}
+                                aria-hidden="true"
                               />
                               <span className="pointer-events-none absolute left-1/2 top-full z-10 mt-2 w-72 -translate-x-1/2 rounded-md bg-gray-900 px-3 py-2 text-xs font-normal leading-5 text-white opacity-0 shadow-lg transition-opacity duration-150 group-hover:opacity-100 group-focus-within:opacity-100">
                                 {rentalPerDayTooltipText}

--- a/frontendNext/app/lending/edit/[id]/page.tsx
+++ b/frontendNext/app/lending/edit/[id]/page.tsx
@@ -484,11 +484,14 @@ export default function EditBookPage() {
                         label={
                           <span className="flex items-center gap-1.5">
                             <span>Deposit Fee*</span>
-                            <span className="group relative inline-flex items-center">
+                            <span
+                              className="group relative inline-flex items-center"
+                              aria-label={depositTooltipText}
+                              title={depositTooltipText}
+                            >
                               <CircleHelp
                                 className="h-4 w-4 cursor-help text-gray-400"
-                                aria-label={depositTooltipText}
-                                title={depositTooltipText}
+                                aria-hidden="true"
                               />
                               <span className="pointer-events-none absolute left-1/2 top-full z-10 mt-2 w-64 -translate-x-1/2 rounded-md bg-gray-900 px-3 py-2 text-xs font-normal leading-5 text-white opacity-0 shadow-lg transition-opacity duration-150 group-hover:opacity-100 group-focus-within:opacity-100">
                                 {depositTooltipText}
@@ -506,11 +509,14 @@ export default function EditBookPage() {
                         <label className="block text-sm font-medium text-gray-700 mb-2">
                           <span className="flex items-center gap-1.5">
                             <span>Rental/Day*</span>
-                            <span className="group relative inline-flex items-center">
+                            <span
+                              className="group relative inline-flex items-center"
+                              aria-label={rentalPerDayTooltipText}
+                              title={rentalPerDayTooltipText}
+                            >
                               <CircleHelp
                                 className="h-4 w-4 cursor-help text-gray-400"
-                                aria-label={rentalPerDayTooltipText}
-                                title={rentalPerDayTooltipText}
+                                aria-hidden="true"
                               />
                               <span className="pointer-events-none absolute left-1/2 top-full z-10 mt-2 w-72 -translate-x-1/2 rounded-md bg-gray-900 px-3 py-2 text-xs font-normal leading-5 text-white opacity-0 shadow-lg transition-opacity duration-150 group-hover:opacity-100 group-focus-within:opacity-100">
                                 {rentalPerDayTooltipText}

--- a/frontendNext/app/message/page.tsx
+++ b/frontendNext/app/message/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, type ReactNode } from "react";
 import { getCurrentUser, getApiUrl, getToken } from "@/utils/auth";
 import { useSearchParams, useRouter } from "next/navigation";
 import type { ChatThread, Message, SendMessageData } from "@/app/types/message";
@@ -56,7 +56,7 @@ const formatTimeAgo = (dateStr: string) => {
   return `${days} days ago`;
 };
 
-const NOTIF_ICON_MAP: Record<string, { bg: string; color: string; icon: JSX.Element }> = {
+const NOTIF_ICON_MAP: Record<string, { bg: string; color: string; icon: ReactNode }> = {
   PAYMENT_CONFIRMED: {
     bg: "bg-green-100", color: "text-green-700",
     icon: <svg xmlns="http://www.w3.org/2000/svg" className="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><polyline points="20 6 9 17 4 12"/></svg>,

--- a/frontendNext/app/types/index.ts
+++ b/frontendNext/app/types/index.ts
@@ -15,9 +15,15 @@ export interface Comment {
   orderId: string;
   reviewerId: string;
   revieweeId: string;
+  bookId?: string;
   rating: number;
+  content?: string;
   comment?: string;
+  tags?: string[];
+  type?: "lender" | "borrower";
   createdAt: string;
+  isAnonymous?: boolean;
+  helpfulCount?: number;
 
   reviewerName?: string;
   revieweeName?: string;
@@ -35,5 +41,5 @@ export interface RatingStats {
     4: number;
     5: number;
   };
+  recentComments?: Comment[];
 }
-

--- a/frontendNext/app/types/order.ts
+++ b/frontendNext/app/types/order.ts
@@ -88,6 +88,7 @@ export interface ApiOrder {
   serviceFeeAmount: number;
   shippingOutFeeAmount: number;
   totalPaidAmount: number;
+  paymentId: string | null;
   paymentMethod: string | null;
   paymentTime: string | null;
   contactName: string;

--- a/frontendNext/next.config.ts
+++ b/frontendNext/next.config.ts
@@ -1,10 +1,6 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  typescript: {
-    ignoreBuildErrors: true,
-  },
-  
   allowedDevOrigins: [
     "https://www.bookborrow.org",
     "https://bookborrow.org",
@@ -24,4 +20,3 @@ const nextConfig: NextConfig = {
 };
 
 export default nextConfig;
-

--- a/frontendNext/tsconfig.json
+++ b/frontendNext/tsconfig.json
@@ -13,6 +13,7 @@
     "esModuleInterop": true,
     "module": "esnext",
     "moduleResolution": "bundler",
+    "ignoreDeprecations": "6.0",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",

--- a/scripts/vps/backup_db.sh
+++ b/scripts/vps/backup_db.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DB_CONTAINER="${DB_CONTAINER:-mysql-db}"
+DB_NAME="${DB_NAME:-BookBorrow}"
+DB_USER="${DB_USER:-root}"
+DB_PASSWORD="${DB_PASSWORD:-rootpassword}"
+BACKUP_DIR="${BACKUP_DIR:-/root/capstone15/backups/bookborrow-db}"
+timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
+output="$BACKUP_DIR/${DB_NAME}-${timestamp}.sql.gz"
+
+mkdir -p "$BACKUP_DIR"
+
+docker exec "$DB_CONTAINER" sh -c \
+  "mysqldump --single-transaction --routines --triggers --events -u'$DB_USER' -p'$DB_PASSWORD' '$DB_NAME'" \
+  | gzip -c > "$output"
+
+printf '%s\n' "$output"

--- a/scripts/vps/check_health.sh
+++ b/scripts/vps/check_health.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DOMAIN="${DOMAIN:-https://www.bookborrow.org}"
+DISK_THRESHOLD="${DISK_THRESHOLD:-85}"
+CERT_WARN_DAYS="${CERT_WARN_DAYS:-21}"
+COMPOSE_FILES="${COMPOSE_FILES:-compose.yaml}"
+
+failures=0
+
+check() {
+  local name="$1"
+  shift
+  if "$@"; then
+    printf '[OK] %s\n' "$name"
+  else
+    printf '[FAIL] %s\n' "$name" >&2
+    failures=$((failures + 1))
+  fi
+}
+
+check "docker compose services are running" \
+  docker compose -f "$COMPOSE_FILES" ps --status running
+
+for service in mysql-db fastapi-backend next-frontend nginx-proxy; do
+  check "$service container exists" docker inspect "$service" >/dev/null
+  restarts="$(docker inspect -f '{{.RestartCount}}' "$service" 2>/dev/null || echo 999)"
+  if [ "$restarts" -gt 0 ]; then
+    printf '[WARN] %s restart count is %s\n' "$service" "$restarts" >&2
+  else
+    printf '[OK] %s restart count is 0\n' "$service"
+  fi
+done
+
+check "backend health endpoint" curl -fsS --max-time 10 http://127.0.0.1:8000/health >/dev/null
+check "public frontend" curl -kfsS --max-time 15 "$DOMAIN" >/dev/null
+check "public books API" curl -kfsS --max-time 15 "$DOMAIN/api/v1/books" >/dev/null
+
+disk_used="$(df -P / | awk 'NR==2 {gsub(/%/, "", $5); print $5}')"
+if [ "$disk_used" -ge "$DISK_THRESHOLD" ]; then
+  printf '[FAIL] disk usage is %s%%, threshold is %s%%\n' "$disk_used" "$DISK_THRESHOLD" >&2
+  failures=$((failures + 1))
+else
+  printf '[OK] disk usage is %s%%\n' "$disk_used"
+fi
+
+host="${DOMAIN#https://}"
+host="${host#http://}"
+host="${host%%/*}"
+expiry_epoch="$(
+  echo | openssl s_client -servername "$host" -connect "$host:443" 2>/dev/null \
+    | openssl x509 -noout -enddate 2>/dev/null \
+    | cut -d= -f2 \
+    | xargs -I{} date -d "{}" +%s 2>/dev/null || true
+)"
+
+if [ -n "$expiry_epoch" ]; then
+  now_epoch="$(date +%s)"
+  days_left=$(( (expiry_epoch - now_epoch) / 86400 ))
+  if [ "$days_left" -lt "$CERT_WARN_DAYS" ]; then
+    printf '[FAIL] TLS certificate expires in %s days\n' "$days_left" >&2
+    failures=$((failures + 1))
+  else
+    printf '[OK] TLS certificate expires in %s days\n' "$days_left"
+  fi
+else
+  printf '[WARN] TLS certificate expiry check skipped\n' >&2
+fi
+
+if [ "$failures" -gt 0 ]; then
+  exit 1
+fi

--- a/scripts/vps/restore_db.sh
+++ b/scripts/vps/restore_db.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "${1:-}" = "" ]; then
+  echo "Usage: $0 <backup.sql.gz>" >&2
+  exit 2
+fi
+
+backup_file="$1"
+DB_CONTAINER="${DB_CONTAINER:-mysql-db}"
+DB_NAME="${DB_NAME:-BookBorrow}"
+DB_USER="${DB_USER:-root}"
+DB_PASSWORD="${DB_PASSWORD:-rootpassword}"
+
+if [ ! -f "$backup_file" ]; then
+  echo "Backup file not found: $backup_file" >&2
+  exit 2
+fi
+
+gzip -dc "$backup_file" | docker exec -i "$DB_CONTAINER" sh -c \
+  "mysql -u'$DB_USER' -p'$DB_PASSWORD' '$DB_NAME'"
+
+printf 'Restored %s into %s/%s\n' "$backup_file" "$DB_CONTAINER" "$DB_NAME"

--- a/scripts/vps/rollback.sh
+++ b/scripts/vps/rollback.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ref="${1:-}"
+if [ -z "$ref" ]; then
+  echo "Usage: $0 <git-ref>" >&2
+  exit 2
+fi
+
+git fetch origin --prune
+git checkout "$ref"
+docker compose -f compose.yaml build
+docker compose -f compose.yaml up -d
+docker compose -f compose.yaml ps
+git log -1 --oneline


### PR DESCRIPTION
## Summary
- remove the frontend TypeScript build bypass and fix the blocking type errors
- move Phase 2 schema patching into an Alembic migration and remove runtime ensure_* ALTER logic
- reduce recurring startup warning noise from seed/passlib-bcrypt behavior
- add a production runbook for verification, email/payment smoke checks, monitoring, backup, restore, and rollback
- add VPS health, backup, restore, and rollback scripts
- update deployment workflow to deploy BookBorrow from VPSdeployment instead of the old Bookhive path

## Verification
- docker compose -f compose.yaml -f compose.dev.yaml config --services
- docker compose -f compose.yaml -f compose.dev.yaml build backend
- docker compose -f compose.yaml -f compose.dev.yaml exec -T backend alembic -c alembic.ini upgrade head
- docker compose -f compose.yaml -f compose.dev.yaml build frontend
- curl checks: frontend root 200, backend /health 200, nginx /api/v1/books 200
- bash -n scripts/vps/check_health.sh scripts/vps/backup_db.sh scripts/vps/restore_db.sh scripts/vps/rollback.sh

## Notes
- Stacked on #96 because the hardening work assumes the BookBorrow compose/database rename baseline.
- Ref #86; this implements the repository-side hardening, but production cron/alert activation and a real restore drill still need to be executed on the VPS after merge.