### PR TITLE
FE3: Fix - Unblock Phase B Production Build

### DIFF
--- a/frontendNext/utils/datetime.ts
+++ b/frontendNext/utils/datetime.ts
@@ -6,16 +6,20 @@
 
 const PERTH_TZ = "Australia/Perth";
 const HAS_TZ_SUFFIX = /Z$|[+-]\d{2}:?\d{2}$/;
+type DateInput = string | Date;
 
 // Exported for callers that need an epoch-ms or Date for sorting/maths and
 // must respect the same naive-string convention as the formatters.
-export function parseAsUtc(value: string): Date {
+export function parseAsUtc(value: DateInput): Date {
+  if (value instanceof Date) {
+    return value;
+  }
   const trimmed = value.trim();
   const normalised = HAS_TZ_SUFFIX.test(trimmed) ? trimmed : trimmed + "Z";
   return new Date(normalised);
 }
 
-export function formatLocalDateTime(value?: string | null, fallback = "—"): string {
+export function formatLocalDateTime(value?: DateInput | null, fallback = "—"): string {
   if (!value) return fallback;
   const dt = parseAsUtc(value);
   if (Number.isNaN(dt.getTime())) return fallback;
@@ -26,7 +30,7 @@ export function formatLocalDateTime(value?: string | null, fallback = "—"): st
   }).format(dt);
 }
 
-export function formatLocalDate(value?: string | null, fallback = "—"): string {
+export function formatLocalDate(value?: DateInput | null, fallback = "—"): string {
   if (!value) return fallback;
   const dt = parseAsUtc(value);
   if (Number.isNaN(dt.getTime())) return fallback;
@@ -36,7 +40,7 @@ export function formatLocalDate(value?: string | null, fallback = "—"): string
   }).format(dt);
 }
 
-export function formatJoinMonth(value?: string | null, fallback = "—"): string {
+export function formatJoinMonth(value?: DateInput | null, fallback = "—"): string {
   if (!value) return fallback;
   const dt = parseAsUtc(value);
   if (Number.isNaN(dt.getTime())) return fallback;


### PR DESCRIPTION
## Summary
- Allow Perth time date formatters to accept already-parsed `Date` values as well as backend ISO strings.
- Fixes the production build failure in PR #102 at `frontendNext/app/profile/[id]/page.tsx`.

## Why
PR #102 centralised Perth time formatting, but existing auth/user utilities expose `createdAt` as a `Date` in some profile pages. The formatter accepted only `string`, so `next build` failed during production type checking.

## Verification
- Local Docker frontend production build passed:
  `docker build --build-arg NEXT_PUBLIC_API_URL=http://localhost --build-arg NEXT_PUBLIC_WS_URL=ws://localhost:8000 --build-arg NEXT_PUBLIC_STRIPE_PK=dummy --build-arg NEXT_PUBLIC_STRIPE_TEST_DESTINATION_ACCOUNT_ID=dummy -t bookborrow-frontend-buildcheck ./frontendNext`
- VPS Docker frontend production build passed on this branch.
- VPS deployment completed with this branch: Docker rebuild, Alembic upgrade to `20260502_0004`, backfill `--apply`, nginx restart, health checks.
- Production checks passed:
  - `https://www.bookborrow.org` -> 200
  - `https://www.bookborrow.org/api/v1/books` -> 200
  - `http://127.0.0.1:8000/health` -> 200