### PR TITLE
VPS07: Persist uploaded media across deploys

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,12 @@ health: ## Run production health checks
 backup-db: ## Create a Docker MySQL database backup
 	bash scripts/vps/backup_db.sh
 
+backup-media: ## Create a Docker media volume backup
+	bash scripts/vps/backup_media.sh
+
+migrate-media: ## Copy current backend /app/media into the persistent media volume
+	bash scripts/vps/migrate_media_volume.sh
+
 rollback: ## Roll back to a git ref and rebuild production containers (usage: make rollback REF=<ref>)
 	bash scripts/vps/rollback.sh $(REF)
 

--- a/README.md
+++ b/README.md
@@ -370,6 +370,8 @@ make logs
 make migrate
 make health
 make backup-db
+make backup-media
+make migrate-media
 ```
 
 ### Development

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -30,7 +30,7 @@ services:
     env_file:
       - ./.env
     command: ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
-    volumes:
+    volumes: !override
       - ./fastapi:/app
     depends_on:
       db:

--- a/compose.yaml
+++ b/compose.yaml
@@ -24,6 +24,8 @@ services:
       - "8000:8000"          # Host:Container
     env_file:
       - ./.env
+    volumes:
+      - bookborrow_media:/app/media
     depends_on:
       - db
     networks:
@@ -71,6 +73,8 @@ services:
 volumes:
   mysql_data:
     name: bookborrow_mysql_data
+  bookborrow_media:
+    name: bookborrow_media
 
 networks:
   mynetwork:

--- a/docs/production-runbook.md
+++ b/docs/production-runbook.md
@@ -11,6 +11,7 @@ BookHive-to-BookBorrow migration.
 - Public URL: `https://www.bookborrow.org`
 - Database: Docker MySQL container `mysql-db`, database `BookBorrow`
 - Database volume: `bookborrow_mysql_data`
+- Uploaded media volume: `bookborrow_media`
 
 ## Standard Deployment
 
@@ -18,6 +19,8 @@ BookHive-to-BookBorrow migration.
 cd /root/capstone15/Bookborrow
 git fetch origin
 git pull --ff-only origin main
+# Run this once before the first deployment that introduces bookborrow_media.
+bash scripts/vps/migrate_media_volume.sh
 docker compose -f compose.yaml build
 docker compose -f compose.yaml up -d
 docker compose -f compose.yaml exec backend alembic -c alembic.ini upgrade head
@@ -26,6 +29,8 @@ docker compose -f compose.yaml ps
 
 Run migrations after the containers are healthy and before accepting traffic
 for schema-dependent changes.
+After the media volume has been introduced once, `migrate_media_volume.sh`
+does not need to be part of every standard deployment.
 
 ## Production Smoke Checks
 
@@ -92,23 +97,45 @@ Example cron entry:
 
 ## Backups
 
-Manual backup:
+Database backup:
 
 ```bash
 cd /root/capstone15/Bookborrow
 bash scripts/vps/backup_db.sh
 ```
 
+Media backup:
+
+```bash
+cd /root/capstone15/Bookborrow
+bash scripts/vps/backup_media.sh
+```
+
 Recommended daily cron:
 
 ```cron
 15 18 * * * cd /root/capstone15/Bookborrow && bash scripts/vps/backup_db.sh >> /var/log/bookborrow-backup.log 2>&1
+25 18 * * * cd /root/capstone15/Bookborrow && bash scripts/vps/backup_media.sh >> /var/log/bookborrow-media-backup.log 2>&1
 ```
 
 The default backup directory is:
 
 ```text
 /root/capstone15/backups/bookborrow-db
+/root/capstone15/backups/bookborrow-media
+```
+
+## Media Volume Migration
+
+Uploaded files are stored under `/app/media` and served through `/media/...`.
+Before the first deployment that introduces the `bookborrow_media` Docker
+volume, copy the current container media files into the named volume:
+
+```bash
+cd /root/capstone15/Bookborrow
+bash scripts/vps/migrate_media_volume.sh
+docker compose -f compose.yaml up -d backend nginx
+curl -k -I https://www.bookborrow.org/media/<known-upload-path>
 ```
 
 ## Restore Drill

--- a/scripts/vps/backup_media.sh
+++ b/scripts/vps/backup_media.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MEDIA_VOLUME="${MEDIA_VOLUME:-bookborrow_media}"
+BACKUP_DIR="${BACKUP_DIR:-/root/capstone15/backups/bookborrow-media}"
+timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
+output="$BACKUP_DIR/${MEDIA_VOLUME}-${timestamp}.tar.gz"
+output_file="$(basename "$output")"
+
+mkdir -p "$BACKUP_DIR"
+
+docker volume inspect "$MEDIA_VOLUME" >/dev/null
+docker run --rm \
+  -v "$MEDIA_VOLUME:/media:ro" \
+  -v "$BACKUP_DIR:/backup" \
+  alpine:3.20 \
+  sh -c "cd /media && tar -czf /backup/$output_file ."
+
+printf '%s\n' "$output"

--- a/scripts/vps/migrate_media_volume.sh
+++ b/scripts/vps/migrate_media_volume.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BACKEND_CONTAINER="${BACKEND_CONTAINER:-fastapi-backend}"
+MEDIA_VOLUME="${MEDIA_VOLUME:-bookborrow_media}"
+BACKUP_DIR="${BACKUP_DIR:-/root/capstone15/backups/bookborrow-media}"
+timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
+snapshot_dir="$BACKUP_DIR/container-media-${timestamp}"
+
+mkdir -p "$BACKUP_DIR"
+docker volume create "$MEDIA_VOLUME" >/dev/null
+
+if docker inspect "$BACKEND_CONTAINER" >/dev/null 2>&1 && docker exec "$BACKEND_CONTAINER" test -d /app/media; then
+  docker cp "$BACKEND_CONTAINER:/app/media" "$snapshot_dir"
+else
+  mkdir -p "$snapshot_dir"
+fi
+
+docker run --rm \
+  -v "$MEDIA_VOLUME:/media" \
+  -v "$snapshot_dir:/snapshot:ro" \
+  alpine:3.20 \
+  sh -c "mkdir -p /media && cp -a /snapshot/. /media/"
+
+printf 'media_snapshot=%s\n' "$snapshot_dir"
+printf 'media_volume=%s\n' "$MEDIA_VOLUME"


### PR DESCRIPTION
## Summary
- Persist uploaded media under the backend with the `bookborrow_media` Docker volume.
- Add VPS scripts to migrate existing `/app/media` content into the volume and create media backups.
- Document the one-time migration step, media backup command, and cron recommendation in the production runbook.

## Why
Uploaded book covers and other files were stored inside the backend container filesystem. Recreating or rebuilding the container could make existing uploaded media unavailable unless it was copied out first.

## Deployment Notes
Before the first production deployment that includes this PR, run:

```bash
bash scripts/vps/migrate_media_volume.sh
```

After that, normal container rebuilds should keep uploaded media in the named Docker volume.

## Validation
- `docker compose -f compose.yaml build backend frontend`
- `docker compose -f compose.yaml config`
- `docker compose -f compose.yaml -f compose.dev.yaml config`
- `bash -n scripts/vps/backup_media.sh scripts/vps/migrate_media_volume.sh`
- Temporary Docker volume/container test for media migration and backup scripts
- `git diff --check`
