### PR TITLE
Implement CSV/PDF report export feature and Improve admin reporting dashboard

### DIFF
--- a/frontendNext/app/admin/book-metrics/page.tsx
+++ b/frontendNext/app/admin/book-metrics/page.tsx
@@ -172,6 +172,11 @@ export default function BookMetricsPage() {
         const fetchUsers = async () => {
             const trimmed = searchText.trim();
 
+            if (selectedUser && trimmed === selectedUser.name) {
+                setMatchedUsers([]);
+                return;
+            }
+
             if (!trimmed) {
                 setMatchedUsers([]);
                 return;
@@ -209,7 +214,7 @@ export default function BookMetricsPage() {
 
         const timeout = setTimeout(fetchUsers, 300);
         return () => clearTimeout(timeout);
-    }, [searchText, token]);
+    }, [searchText, selectedUser, token]);
 
     const handleSelectUser = async (user: UserSearchResult) => {
         try {
@@ -536,7 +541,7 @@ export default function BookMetricsPage() {
                             <p className="text-sm text-gray-500 mt-2">Searching users...</p>
                         )}
 
-                        {matchedUsers.length > 0 && (
+                        {matchedUsers.length > 0 && !selectedUser && (
                             <div className="absolute z-10 mt-1 w-full bg-white border rounded-lg shadow-lg max-h-56 overflow-y-auto">
                                 {matchedUsers.map((user) => (
                                     <button
@@ -606,7 +611,14 @@ export default function BookMetricsPage() {
                             {userBooks.length > 0 ? (
                                 userBooks.map((book) => (
                                     <tr key={book.id} className="border-b hover:bg-gray-50">
-                                        <td className="py-3 px-4">{book.title_or || "-"}</td>
+                                        <td className="py-3 px-4">
+                                            <Link
+                                                href={`/books/${book.id}`}
+                                                className="font-medium text-blue-600 underline"
+                                            >
+                                                {book.title_or || "-"}
+                                            </Link>
+                                        </td>
                                         <td className="py-3 px-4">{book.author || "-"}</td>
                                         <td className="py-3 px-4">{book.category || "-"}</td>
                                         <td className="py-3 px-4">{book.status || "-"}</td>

--- a/frontendNext/app/admin/financial-metrics/page.tsx
+++ b/frontendNext/app/admin/financial-metrics/page.tsx
@@ -3,7 +3,14 @@
 import { useEffect, useState } from "react";
 import Link from "next/link";
 import { getCurrentUser } from "@/utils/auth";
-import { BarChart3, CircleDollarSign, ReceiptText, TrendingUp } from "lucide-react";
+import {
+    BarChart3,
+    CalendarRange,
+    CircleDollarSign,
+    ReceiptText,
+    SlidersHorizontal,
+    TrendingUp,
+} from "lucide-react";
 import {
     getFinancialMetrics,
     getPlatformFeeSetting,
@@ -55,14 +62,20 @@ export default function FinancialMetricsPage() {
         }
     };
 
-    const fetchFinancialMetrics = async (useFilter = false) => {
+    const fetchFinancialMetrics = async (
+        useFilter = false,
+        overrideDates?: { fromDate?: string; toDate?: string }
+    ) => {
         if (useFilter) setFilterLoading(true);
         setError("");
 
         try {
             const params: { from_date?: string; to_date?: string } = {};
-            if (fromDate) params.from_date = fromDate;
-            if (toDate) params.to_date = toDate;
+            const selectedFromDate = overrideDates?.fromDate ?? fromDate;
+            const selectedToDate = overrideDates?.toDate ?? toDate;
+
+            if (selectedFromDate) params.from_date = selectedFromDate;
+            if (selectedToDate) params.to_date = selectedToDate;
 
             const result = await getFinancialMetrics(params);
             setMetrics(result);
@@ -142,6 +155,42 @@ export default function FinancialMetricsPage() {
         await fetchFinancialMetrics(true);
     };
 
+    const formatDateInput = (date: Date) => {
+        const year = date.getFullYear();
+        const month = String(date.getMonth() + 1).padStart(2, "0");
+        const day = String(date.getDate()).padStart(2, "0");
+        return `${year}-${month}-${day}`;
+    };
+
+    const handleQuickFilter = async (range: "today" | "week" | "month" | "clear") => {
+        let nextFromDate = "";
+        let nextToDate = "";
+
+        if (range !== "clear") {
+            const today = new Date();
+            const from = new Date(today);
+
+            if (range === "week") {
+                from.setDate(today.getDate() - 6);
+            }
+
+            if (range === "month") {
+                from.setDate(1);
+            }
+
+            nextFromDate = formatDateInput(from);
+            nextToDate = formatDateInput(today);
+        }
+
+        setFromDate(nextFromDate);
+        setToDate(nextToDate);
+        setDateError("");
+        await fetchFinancialMetrics(true, {
+            fromDate: nextFromDate,
+            toDate: nextToDate,
+        });
+    };
+
     if (loading) {
         return <p className="text-gray-600">Loading financial metrics...</p>;
     }
@@ -167,87 +216,6 @@ export default function FinancialMetricsPage() {
                 <Link href="/admin" className="text-sm underline self-center">
                     Back to Dashboard
                 </Link>
-            </div>
-
-            {error && (
-                <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
-                    {error}
-                </div>
-            )}
-
-            {successMessage && (
-                <div className="rounded-lg border border-green-200 bg-green-50 px-4 py-3 text-sm text-green-700">
-                    {successMessage}
-                </div>
-            )}
-
-            <div className="bg-white rounded-xl shadow-sm border p-5">
-                <h2 className="text-lg font-semibold mb-2">Platform Fee Setting</h2>
-                <p className="text-sm text-gray-600 mb-4">
-                </p>
-
-                <div className="grid grid-cols-1 md:grid-cols-3 gap-4 items-end">
-                    <div>
-                        <label className="block text-sm font-medium mb-2">
-                            Max Value / Fee per Transaction (AUD)
-                        </label>
-                        <input
-                            type="number"
-                            min="0"
-                            step="0.01"
-                            value={platformFee}
-                            onChange={(e) => setPlatformFee(Number(e.target.value))}
-                            className="w-full rounded-lg border px-3 py-2"
-                        />
-                    </div>
-
-                    <button
-                        onClick={handleUpdatePlatformFee}
-                        disabled={feeSaving}
-                        className="rounded-lg bg-green-600 text-white px-4 py-2 font-medium hover:bg-green-700 disabled:opacity-60"
-                    >
-                        {feeSaving ? "Saving..." : "Update Fee"}
-                    </button>
-                </div>
-            </div>
-
-            <div className="bg-white rounded-xl shadow-sm border p-5 mb-8">
-                <h2 className="text-lg font-semibold mb-4">Filter Transactions</h2>
-
-                <div className="grid grid-cols-1 md:grid-cols-3 gap-4 items-end">
-                    <div>
-                        <label className="block text-sm font-medium mb-2">From</label>
-                        <input
-                            type="date"
-                            value={fromDate}
-                            onChange={(e) => setFromDate(e.target.value)}
-                            className="w-full rounded-lg border px-3 py-2"
-                        />
-                    </div>
-
-                    <div>
-                        <label className="block text-sm font-medium mb-2">To</label>
-                        <input
-                            type="date"
-                            value={toDate}
-                            onChange={(e) => setToDate(e.target.value)}
-                            className="w-full rounded-lg border px-3 py-2"
-                        />
-                    </div>
-
-                    <div>
-                        <button
-                            onClick={handleFilter}
-                            disabled={filterLoading || !!dateError}
-                            className="w-full rounded-lg bg-blue-600 text-white px-4 py-2 font-medium hover:bg-blue-700 disabled:opacity-60"
-                        >
-                            {filterLoading ? "Loading..." : "Filter"}
-                        </button>
-                        {dateError && (
-                            <p className="text-sm text-red-600 mt-2">{dateError}</p>
-                        )}
-                    </div>
-                </div>
             </div>
 
             <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8">
@@ -284,6 +252,125 @@ export default function FinancialMetricsPage() {
                     <h2 className="text-2xl font-bold mt-2">
                         ${metrics.average_transaction_value.toFixed(2)}
                     </h2>
+                </div>
+            </div>
+
+            <div className="grid grid-cols-1 xl:grid-cols-[minmax(320px,0.8fr)_minmax(0,1.6fr)] gap-5">
+                <div className="bg-white rounded-xl shadow-sm border p-5">
+                    <div className="flex items-center gap-2 mb-4">
+                        <SlidersHorizontal className="w-5 h-5 text-green-600" />
+                        <h2 className="text-lg font-semibold">Platform Fee Setting</h2>
+                    </div>
+
+                    {error && (
+                        <div className="rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700 mb-3">
+                            {error}
+                        </div>
+                    )}
+
+                    {successMessage && (
+                        <div className="rounded-lg border border-green-200 bg-green-50 px-3 py-2 text-sm text-green-700 mb-3">
+                            {successMessage}
+                        </div>
+                    )}
+
+                    <label className="block text-sm font-medium mb-2">
+                        Fee per transaction (AUD)
+                    </label>
+                    <div className="grid grid-cols-1 sm:grid-cols-[1fr_auto] gap-3">
+                        <input
+                            type="number"
+                            min="0"
+                            step="0.01"
+                            value={platformFee}
+                            onChange={(e) => setPlatformFee(Number(e.target.value))}
+                            className="w-full rounded-lg border px-3 py-2"
+                        />
+                        <button
+                            onClick={handleUpdatePlatformFee}
+                            disabled={feeSaving}
+                            className="rounded-lg bg-green-600 text-white px-5 py-2 font-medium hover:bg-green-700 disabled:opacity-60"
+                        >
+                            {feeSaving ? "Saving..." : "Update"}
+                        </button>
+                    </div>
+                </div>
+
+                <div className="bg-white rounded-xl shadow-sm border p-5">
+                    <div className="flex flex-wrap items-center justify-between gap-3 mb-4">
+                        <div className="flex items-center gap-2">
+                            <CalendarRange className="w-5 h-5 text-blue-600" />
+                            <h2 className="text-lg font-semibold">Filter Transactions</h2>
+                        </div>
+                        <div className="flex flex-wrap gap-2">
+                            <button
+                                type="button"
+                                onClick={() => handleQuickFilter("today")}
+                                disabled={filterLoading}
+                                className="rounded-lg border px-3 py-1.5 text-sm font-medium hover:bg-gray-50 disabled:opacity-60"
+                            >
+                                Today
+                            </button>
+                            <button
+                                type="button"
+                                onClick={() => handleQuickFilter("week")}
+                                disabled={filterLoading}
+                                className="rounded-lg border px-3 py-1.5 text-sm font-medium hover:bg-gray-50 disabled:opacity-60"
+                            >
+                                Last 7 days
+                            </button>
+                            <button
+                                type="button"
+                                onClick={() => handleQuickFilter("month")}
+                                disabled={filterLoading}
+                                className="rounded-lg border px-3 py-1.5 text-sm font-medium hover:bg-gray-50 disabled:opacity-60"
+                            >
+                                This month
+                            </button>
+                            <button
+                                type="button"
+                                onClick={() => handleQuickFilter("clear")}
+                                disabled={filterLoading}
+                                className="rounded-lg border px-3 py-1.5 text-sm font-medium hover:bg-gray-50 disabled:opacity-60"
+                            >
+                                Clear
+                            </button>
+                        </div>
+                    </div>
+
+                    <div className="grid grid-cols-1 lg:grid-cols-[1fr_1fr_auto] gap-3 items-end">
+                        <div>
+                            <label className="block text-sm font-medium mb-2">From</label>
+                            <input
+                                type="date"
+                                value={fromDate}
+                                onChange={(e) => setFromDate(e.target.value)}
+                                className="w-full rounded-lg border px-3 py-2"
+                            />
+                        </div>
+
+                        <div>
+                            <label className="block text-sm font-medium mb-2">To</label>
+                            <input
+                                type="date"
+                                value={toDate}
+                                onChange={(e) => setToDate(e.target.value)}
+                                className="w-full rounded-lg border px-3 py-2"
+                            />
+                        </div>
+
+                        <button
+                            onClick={handleFilter}
+                            disabled={filterLoading || !!dateError}
+                            className="rounded-lg bg-blue-600 text-white px-8 py-2 font-medium hover:bg-blue-700 disabled:opacity-60"
+                        >
+                            {filterLoading ? "Loading..." : "Filter"}
+                        </button>
+                    </div>
+
+                    {dateError && (
+                        <p className="text-sm text-red-600 mt-2">{dateError}</p>
+                    )}
                 </div>
             </div>
 

--- a/frontendNext/app/admin/refunds/page.tsx
+++ b/frontendNext/app/admin/refunds/page.tsx
@@ -15,6 +15,8 @@ import {
   ChevronLeft,
   ChevronRight,
   Plus,
+  Download,
+  FileText,
 } from "lucide-react";
 import { getCurrentUser } from "@/utils/auth";
 import { getAdminRefunds, manualAdminRefund } from "@/utils/payments";
@@ -91,6 +93,152 @@ interface Pagination {
   total_pages: number;
 }
 
+function csvEscape(value: string) {
+  return `"${value.replace(/"/g, '""')}"`;
+}
+
+function escapeHtml(value: string) {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#039;");
+}
+
+function downloadTextFile(filename: string, content: string, mimeType: string) {
+  const blob = new Blob([content], { type: mimeType });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(url);
+}
+
+function formatRefundAmount(cents: number, currency: string) {
+  const dollars = (cents / 100).toFixed(2);
+  const sym = currency?.toUpperCase() === "AUD" ? "A$" : "$";
+  return `${sym}${dollars}`;
+}
+
+function buildRefundReportRows(refunds: AdminRefundItem[]) {
+  return refunds.map((refund) => ({
+    "Refund ID": refund.refund_id,
+    "Payment ID": refund.payment_id,
+    "Order ID": refund.order?.order_id || "-",
+    Books: refund.order?.book_titles?.join("; ") || "-",
+    Borrower: refund.borrower?.name || "-",
+    "Borrower Email": refund.borrower?.email || "-",
+    Lender: refund.lender?.name || "-",
+    "Lender Email": refund.lender?.email || "-",
+    Amount: formatRefundAmount(refund.amount, refund.currency),
+    Status: STATUS_META[refund.status]?.label || refund.status || "-",
+    Type: TYPE_LABELS[refund.refund_type] || refund.refund_type || "-",
+    Trigger: TRIGGER_LABELS[refund.trigger] || refund.trigger || "-",
+    Reason: refund.reason || "-",
+    "Created At": formatLocalDateTime(refund.created_at, "-"),
+    "Updated At": formatLocalDateTime(refund.updated_at, "-"),
+    Disputes: refund.disputes.map((item) => `${item.reason} (${item.status})`).join("; ") || "-",
+  }));
+}
+
+function exportRefundsCsv(refunds: AdminRefundItem[]) {
+  const rows = buildRefundReportRows(refunds);
+  const headers = [
+    "Refund ID",
+    "Payment ID",
+    "Order ID",
+    "Books",
+    "Borrower",
+    "Borrower Email",
+    "Lender",
+    "Lender Email",
+    "Amount",
+    "Status",
+    "Type",
+    "Trigger",
+    "Reason",
+    "Created At",
+    "Updated At",
+    "Disputes",
+  ];
+  const csv = [
+    headers.map(csvEscape).join(","),
+    ...rows.map((row) => headers.map((header) => csvEscape(row[header as keyof typeof row])).join(",")),
+  ].join("\n");
+
+  downloadTextFile("bookborrow-refund-report.csv", csv, "text/csv;charset=utf-8");
+}
+
+function exportRefundsPdf(refunds: AdminRefundItem[]) {
+  const rows = buildRefundReportRows(refunds);
+  const headers = ["Refund ID", "Order ID", "Books", "Borrower", "Lender", "Amount", "Status", "Type", "Trigger", "Created At"];
+  const bodyRows = rows
+    .map(
+      (row) => `
+        <tr>
+          ${headers.map((header) => `<td>${escapeHtml(row[header as keyof typeof row])}</td>`).join("")}
+        </tr>
+      `
+    )
+    .join("");
+
+  const iframe = document.createElement("iframe");
+  iframe.style.position = "fixed";
+  iframe.style.right = "0";
+  iframe.style.bottom = "0";
+  iframe.style.width = "0";
+  iframe.style.height = "0";
+  iframe.style.border = "0";
+  iframe.title = "BookBorrow refund PDF export";
+
+  const html = `
+    <!doctype html>
+    <html>
+      <head>
+        <title>BookBorrow Refund Report</title>
+        <style>
+          body { font-family: Arial, sans-serif; color: #111827; margin: 32px; }
+          h1 { font-size: 24px; margin: 0 0 4px; }
+          .meta { color: #4b5563; margin: 0 0 24px; }
+          table { border-collapse: collapse; width: 100%; }
+          th, td { border: 1px solid #e5e7eb; font-size: 11px; padding: 7px; text-align: left; vertical-align: top; }
+          th { background: #f9fafb; }
+          @media print { body { margin: 14mm; } }
+        </style>
+      </head>
+      <body>
+        <h1>BookBorrow Refund Report</h1>
+        <p class="meta">${rows.length} refund(s) | Generated ${escapeHtml(new Date().toLocaleString())}</p>
+        <table>
+          <thead><tr>${headers.map((header) => `<th>${escapeHtml(header)}</th>`).join("")}</tr></thead>
+          <tbody>${bodyRows}</tbody>
+        </table>
+      </body>
+    </html>
+  `;
+
+  document.body.appendChild(iframe);
+  const iframeDocument = iframe.contentWindow?.document;
+  if (!iframeDocument || !iframe.contentWindow) {
+    iframe.remove();
+    alert("Unable to prepare the PDF export. Please try again.");
+    return;
+  }
+
+  iframeDocument.open();
+  iframeDocument.write(html);
+  iframeDocument.close();
+  window.setTimeout(() => {
+    iframe.contentWindow?.focus();
+    iframe.contentWindow?.print();
+    window.setTimeout(() => iframe.remove(), 1000);
+  }, 100);
+}
+
 export default function AdminRefundsPage() {
   const [loading, setLoading] = useState(true);
   const [meAdmin, setMeAdmin] = useState(false);
@@ -118,6 +266,7 @@ export default function AdminRefundsPage() {
   const [manualRefundType, setManualRefundType] = useState("full");
   const [manualReason, setManualReason] = useState("");
   const [manualSubmitting, setManualSubmitting] = useState(false);
+  const [reportExporting, setReportExporting] = useState(false);
 
   const router = useRouter();
 
@@ -198,13 +347,38 @@ export default function AdminRefundsPage() {
     }
   };
 
-  const fmtAmount = (cents: number, currency: string) => {
-    const dollars = (cents / 100).toFixed(2);
-    const sym = currency?.toUpperCase() === "AUD" ? "A$" : "$";
-    return `${sym}${dollars}`;
-  };
+  const fmtAmount = formatRefundAmount;
 
   const fmtDate = (v?: string | null) => formatLocalDateTime(v, "-");
+
+  const loadRefundReportRows = async () => {
+    if (pagination.total <= refunds.length) return refunds;
+    setReportExporting(true);
+    try {
+      const data = await getAdminRefunds({
+        status_filter: statusFilter || undefined,
+        refund_type: typeFilter || undefined,
+        search: search || undefined,
+        sort_by: sortBy,
+        sort_order: sortOrder,
+        page: 1,
+        page_size: Math.max(pagination.total, 20),
+      });
+      return data.refunds as AdminRefundItem[];
+    } finally {
+      setReportExporting(false);
+    }
+  };
+
+  const handleExportRefundCsv = async () => {
+    const rows = await loadRefundReportRows();
+    exportRefundsCsv(rows);
+  };
+
+  const handleExportRefundPdf = async () => {
+    const rows = await loadRefundReportRows();
+    exportRefundsPdf(rows);
+  };
 
   if (!meAdmin && !loading) {
     return (
@@ -224,6 +398,20 @@ export default function AdminRefundsPage() {
           <p className="text-gray-600">Monitor and manage all refunds across the platform.</p>
         </div>
         <div className="flex gap-2">
+          <button
+            onClick={handleExportRefundCsv}
+            disabled={refunds.length === 0 || reportExporting}
+            className="px-4 py-2 border bg-white rounded-lg text-sm flex items-center gap-1 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            <Download className="w-4 h-4" /> Export CSV
+          </button>
+          <button
+            onClick={handleExportRefundPdf}
+            disabled={refunds.length === 0 || reportExporting}
+            className="px-4 py-2 bg-black text-white rounded-lg text-sm flex items-center gap-1 hover:bg-gray-800 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            <FileText className="w-4 h-4" /> Export PDF
+          </button>
           <button
             onClick={() => setShowManualRefund(true)}
             className="px-4 py-2 bg-blue-600 text-white rounded-lg text-sm flex items-center gap-1 hover:bg-blue-700"

--- a/frontendNext/app/admin/user-metrics/page.tsx
+++ b/frontendNext/app/admin/user-metrics/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import Link from "next/link";
-import { BookMarked, MapPin, UserPlus, Users } from "lucide-react";
+import { BookMarked, CalendarDays, Filter, MapPin, UserPlus, Users } from "lucide-react";
 import { getApiUrl, getToken } from "@/utils/auth";
 import { formatLocalDate } from "@/utils/datetime";
 
@@ -25,6 +25,44 @@ type SignupUser = {
     state: string | null;
     country: string | null;
 };
+
+function DistributionPanel({
+    title,
+    emptyLabel,
+    items,
+}: {
+    title: string;
+    emptyLabel: string;
+    items: { label: string; count: number }[];
+}) {
+    const max = Math.max(...items.map((item) => item.count), 0);
+
+    return (
+        <section className="rounded-lg border bg-white p-5">
+            <h2 className="text-base font-semibold text-gray-950">{title}</h2>
+            <div className="mt-4 space-y-4">
+                {items.length > 0 ? (
+                    items.map((item) => {
+                        const width = max > 0 ? `${Math.max((item.count / max) * 100, 6)}%` : "0%";
+                        return (
+                            <div key={item.label} className="space-y-1.5">
+                                <div className="flex items-center justify-between gap-3 text-sm">
+                                    <span className="truncate text-gray-700">{item.label}</span>
+                                    <span className="font-semibold text-gray-950">{item.count}</span>
+                                </div>
+                                <div className="h-2 rounded-full bg-gray-100">
+                                    <div className="h-2 rounded-full bg-gray-900" style={{ width }} />
+                                </div>
+                            </div>
+                        );
+                    })
+                ) : (
+                    <p className="text-sm text-gray-500">{emptyLabel}</p>
+                )}
+            </div>
+        </section>
+    );
+}
 
 export default function UserMetricsPage() {
     const [metrics, setMetrics] = useState<UserMetricsData>({
@@ -159,170 +197,191 @@ export default function UserMetricsPage() {
         return <p className="text-red-600">{error}</p>;
     }
 
+    const ageItems = Object.entries(demographics.age_groups).map(([label, count]) => ({
+        label,
+        count,
+    }));
+    const locationItems = Object.entries(demographics.locations).map(([label, count]) => ({
+        label,
+        count,
+    }));
+    const readingItems = demographics.reading_preferences.map((item) => ({
+        label: item.category,
+        count: item.count,
+    }));
+    const cards = [
+        {
+            title: "Total Registered Users",
+            value: metrics.total_users,
+            icon: Users,
+            className: "text-blue-600",
+        },
+        {
+            title: "Sign-ups Selected",
+            value: totalSignups,
+            icon: UserPlus,
+            className: "text-green-600",
+        },
+        {
+            title: "Reading Prefs",
+            value: demographics.reading_preferences.length,
+            icon: BookMarked,
+            className: "text-violet-600",
+        },
+        {
+            title: "Locations",
+            value: Object.keys(demographics.locations).length,
+            icon: MapPin,
+            className: "text-orange-600",
+        },
+    ];
+
     return (
-        <div className="max-w-7xl mx-auto p-6 space-y-6">
-            {/* Header */}
-            <div className="flex items-center justify-between">
+        <div className="mx-auto max-w-7xl p-6">
+            <div className="flex flex-col gap-3 border-b border-gray-200 pb-5 md:flex-row md:items-end md:justify-between">
                 <div>
-                    <h1 className="text-2xl font-bold">User Metrics</h1>
-                    <p className="text-gray-600">Overview of registered users and demographics.</p>
+                    <h1 className="text-2xl font-semibold text-gray-950">User Metrics</h1>
+                    <p className="mt-1 text-sm text-gray-600">
+                        Monitor user growth, signup geography, and reading preference patterns.
+                    </p>
                 </div>
-                <Link href="/admin" className="text-sm underline self-center">
+                <Link href="/admin" className="text-sm font-medium text-gray-700 underline">
                     Back to Dashboard
                 </Link>
             </div>
 
-            {/* KPI Cards */}
-            <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-                <div className="rounded-xl border bg-white p-4">
-                    <div className="flex items-center gap-2 text-blue-600 text-sm mb-1">
-                        <Users className="w-4 h-4" /> Total Registered Users
-                    </div>
-                    <div className="text-2xl font-bold">{metrics.total_users}</div>
-                </div>
-
-                <div className="rounded-xl border bg-white p-4">
-                    <div className="flex items-center gap-2 text-green-600 text-sm mb-1">
-                        <UserPlus className="w-4 h-4" /> Sign-ups Selected
-                    </div>
-                    <div className="text-2xl font-bold">{totalSignups}</div>
-                </div>
-
-                <div className="rounded-xl border bg-white p-4">
-                    <div className="flex items-center gap-2 text-violet-600 text-sm mb-1">
-                        <BookMarked className="w-4 h-4" /> Reading Prefs
-                    </div>
-                    <div className="text-2xl font-bold">{demographics.reading_preferences.length}</div>
-                </div>
-
-                <div className="rounded-xl border bg-white p-4">
-                    <div className="flex items-center gap-2 text-orange-600 text-sm mb-1">
-                        <MapPin className="w-4 h-4" /> Locations
-                    </div>
-                    <div className="text-2xl font-bold">{Object.keys(demographics.locations).length}</div>
-                </div>
+            <div className="mt-6 grid grid-cols-2 md:grid-cols-4 gap-4 mb-8">
+                {cards.map((card) => {
+                    const Icon = card.icon;
+                    return (
+                        <div
+                            key={card.title}
+                            className="bg-white rounded-xl shadow-sm border p-5 text-left"
+                        >
+                            <div className={`flex items-center gap-2 text-sm mb-1 ${card.className}`}>
+                                <Icon className="w-4 h-4" /> {card.title}
+                            </div>
+                            <h2 className="text-2xl font-bold mt-2">{card.value}</h2>
+                        </div>
+                    );
+                })}
             </div>
 
-            {/* Filters */}
-            <div className="bg-white rounded-xl shadow-sm border p-4 space-y-3">
-                <div className="grid grid-cols-1 md:grid-cols-3 gap-4 items-end">
+            <section className="mt-6 rounded-lg border bg-white p-5">
+                <div className="flex items-center gap-2">
+                    <CalendarDays className="h-5 w-5 text-gray-500" />
+                    <h2 className="text-base font-semibold text-gray-950">Signup Date Range</h2>
+                </div>
+                <div className="mt-4 grid grid-cols-1 gap-4 md:grid-cols-[1fr_1fr_180px]">
                     <div>
-                        <label className="block text-sm font-medium mb-2">From</label>
+                        <label className="mb-2 block text-sm font-medium text-gray-700">From</label>
                         <input
                             type="date"
                             value={fromDate}
                             onChange={(e) => setFromDate(e.target.value)}
-                            className="w-full rounded-lg border px-3 py-2"
+                            className="h-11 w-full rounded-md border border-gray-300 px-3 text-sm focus:border-gray-900 focus:outline-none focus:ring-1 focus:ring-gray-900"
                         />
                     </div>
-
                     <div>
-                        <label className="block text-sm font-medium mb-2">To</label>
+                        <label className="mb-2 block text-sm font-medium text-gray-700">To</label>
                         <input
                             type="date"
                             value={toDate}
                             onChange={(e) => setToDate(e.target.value)}
-                            className="w-full rounded-lg border px-3 py-2"
+                            className="h-11 w-full rounded-md border border-gray-300 px-3 text-sm focus:border-gray-900 focus:outline-none focus:ring-1 focus:ring-gray-900"
                         />
                     </div>
+                    <button
+                        onClick={fetchSignups}
+                        disabled={signupLoading}
+                        className="inline-flex h-11 items-center justify-center gap-2 self-end rounded-md bg-gray-950 px-4 text-sm font-semibold text-white hover:bg-gray-800 disabled:opacity-60"
+                    >
+                        <Filter className="h-4 w-4" />
+                        {signupLoading ? "Filtering..." : "Filter"}
+                    </button>
+                </div>
+                {error && fromDate && toDate && (
+                    <p className="mt-3 text-sm text-red-600">{error}</p>
+                )}
+            </section>
 
+            <section className="mt-6 rounded-lg border bg-white">
+                <div className="flex flex-col gap-2 border-b border-gray-100 px-5 py-4 md:flex-row md:items-center md:justify-between">
                     <div>
-                        <button
-                            onClick={fetchSignups}
-                            className="w-full rounded-lg bg-blue-600 text-white px-4 py-2 font-medium hover:bg-blue-700"
-                        >
-                            Filter
-                        </button>
+                        <h2 className="text-base font-semibold text-gray-950">User Sign-up Details</h2>
+                        <p className="mt-1 text-sm text-gray-500">
+                            {users.length > 0
+                                ? `${users.length} user${users.length === 1 ? "" : "s"} found for the selected range`
+                                : "Select a date range to inspect new accounts"}
+                        </p>
                     </div>
+                    {fromDate && toDate && (
+                        <span className="rounded-md bg-gray-100 px-3 py-1 text-xs font-medium text-gray-700">
+                            {fromDate} to {toDate}
+                        </span>
+                    )}
                 </div>
-            </div>
 
-            {signupLoading && (
-                <p className="text-gray-600 mb-4">Loading sign-up data...</p>
-            )}
-
-            {error && fromDate && toDate && (
-                <p className="text-red-600 mb-4">{error}</p>
-            )}
-
-            {/* Table */}
-            <div className="rounded-xl border bg-white overflow-hidden">
-                <div className="p-6">
-                    <h2 className="text-xl font-semibold mb-4">User Sign-up Details</h2>
-
-                    <div className="overflow-x-auto">
-                        <table className="w-full text-sm">
-                            <thead className="bg-gray-50 border-b">
-                                <tr>
-                                    <th className="text-left px-4 py-3 font-medium text-gray-600">Name</th>
-                                    <th className="text-left px-4 py-3 font-medium text-gray-600">Email</th>
-                                    <th className="text-left px-4 py-3 font-medium text-gray-600">Created Date</th>
-                                    <th className="text-left px-4 py-3 font-medium text-gray-600">City</th>
-                                    <th className="text-left px-4 py-3 font-medium text-gray-600">State</th>
-                                    <th className="text-left px-4 py-3 font-medium text-gray-600">Country</th>
-                                </tr>
-                            </thead>
-                            <tbody className="divide-y">
-                                {users.length > 0 ? (
-                                    users.map((user) => (
-                                        <tr key={user.user_id} className="hover:bg-gray-50">
-                                            <td className="px-4 py-3">{user.name || "-"}</td>
-                                            <td className="px-4 py-3">{user.email || "-"}</td>
-                                            <td className="px-4 py-3">{formatLocalDate(user.created_at, "-")}</td>
-                                            <td className="px-4 py-3">{user.city || "-"}</td>
-                                            <td className="px-4 py-3">{user.state || "-"}</td>
-                                            <td className="px-4 py-3">{user.country || "-"}</td>
-                                        </tr>
-                                    ))
-                                ) : (
-                                    <tr>
-                                        <td colSpan={6} className="p-8 text-center text-gray-500">
-                                            No sign-ups found for the selected period.
-                                        </td>
+                <div className="overflow-x-auto">
+                    <table className="w-full text-sm">
+                        <thead className="bg-gray-50 text-gray-600">
+                            <tr>
+                                <th className="px-5 py-3 text-left font-medium">Name</th>
+                                <th className="px-5 py-3 text-left font-medium">Email</th>
+                                <th className="px-5 py-3 text-left font-medium">Created Date</th>
+                                <th className="px-5 py-3 text-left font-medium">City</th>
+                                <th className="px-5 py-3 text-left font-medium">State</th>
+                                <th className="px-5 py-3 text-left font-medium">Country</th>
+                            </tr>
+                        </thead>
+                        <tbody className="divide-y divide-gray-100">
+                            {users.length > 0 ? (
+                                users.map((user) => (
+                                    <tr key={user.user_id} className="hover:bg-gray-50">
+                                        <td className="px-5 py-4 font-medium text-gray-950">{user.name || "-"}</td>
+                                        <td className="px-5 py-4 text-gray-700">{user.email || "-"}</td>
+                                        <td className="px-5 py-4 text-gray-700">{formatLocalDate(user.created_at, "-")}</td>
+                                        <td className="px-5 py-4 text-gray-700">{user.city || "-"}</td>
+                                        <td className="px-5 py-4 text-gray-700">{user.state || "-"}</td>
+                                        <td className="px-5 py-4 text-gray-700">{user.country || "-"}</td>
                                     </tr>
-                                )}
-                            </tbody>
-                        </table>
-                    </div>
+                                ))
+                            ) : (
+                                <tr>
+                                    <td colSpan={6} className="px-5 py-12 text-center">
+                                        <div className="mx-auto max-w-sm">
+                                            <Users className="mx-auto h-8 w-8 text-gray-300" />
+                                            <p className="mt-3 font-medium text-gray-700">
+                                                No sign-ups found
+                                            </p>
+                                            <p className="mt-1 text-sm text-gray-500">
+                                                Choose a different date range to check user registrations.
+                                            </p>
+                                        </div>
+                                    </td>
+                                </tr>
+                            )}
+                        </tbody>
+                    </table>
                 </div>
-            </div>
+            </section>
 
-            <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-                <div className="bg-white rounded-xl shadow-sm border p-5">
-                    <h2 className="text-xl font-semibold mb-4">Age Distribution</h2>
-                    <div className="space-y-2">
-                        {Object.entries(demographics.age_groups).map(([group, count]) => (
-                            <div key={group} className="flex justify-between">
-                                <span>{group}</span>
-                                <span className="font-semibold">{count}</span>
-                            </div>
-                        ))}
-                    </div>
-                </div>
-
-                <div className="bg-white rounded-xl shadow-sm border p-5">
-                    <h2 className="text-xl font-semibold mb-4">Location Distribution</h2>
-                    <div className="space-y-2">
-                        {Object.entries(demographics.locations).map(([location, count]) => (
-                            <div key={location} className="flex justify-between">
-                                <span>{location}</span>
-                                <span className="font-semibold">{count}</span>
-                            </div>
-                        ))}
-                    </div>
-                </div>
-
-                <div className="bg-white rounded-xl shadow-sm border p-5">
-                    <h2 className="text-xl font-semibold mb-4">Reading Preferences</h2>
-                    <div className="space-y-2">
-                        {demographics.reading_preferences.map((item) => (
-                            <div key={item.category} className="flex justify-between">
-                                <span>{item.category}</span>
-                                <span className="font-semibold">{item.count}</span>
-                            </div>
-                        ))}
-                    </div>
-                </div>
+            <div className="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-3">
+                <DistributionPanel
+                    title="Age Distribution"
+                    emptyLabel="No age data available."
+                    items={ageItems}
+                />
+                <DistributionPanel
+                    title="Location Distribution"
+                    emptyLabel="No location data available."
+                    items={locationItems}
+                />
+                <DistributionPanel
+                    title="Reading Preferences"
+                    emptyLabel="No reading preference data available."
+                    items={readingItems}
+                />
             </div>
         </div>
     );

--- a/frontendNext/app/admin/users/page.tsx
+++ b/frontendNext/app/admin/users/page.tsx
@@ -124,6 +124,12 @@ export default function AdminUsersPage() {
 
   useEffect(() => {
     const query = lookupId.trim();
+    if (lookupResult && query === `${lookupResult.name} (${lookupResult.email})`) {
+      setSearchResults([]);
+      setDropdownOpen(false);
+      return;
+    }
+
     if (query.length < 2) {
       setSearchResults([]);
       setDropdownOpen(false);
@@ -303,7 +309,7 @@ export default function AdminUsersPage() {
                 setLookupResult(null);
               }}
               onFocus={() => {
-                if (searchResults.length > 0) setDropdownOpen(true);
+                if (!lookupResult && searchResults.length > 0) setDropdownOpen(true);
               }}
               onKeyDown={(e) => {
                 if (e.key === "Enter") handleLookup();
@@ -313,7 +319,7 @@ export default function AdminUsersPage() {
               className="w-full border rounded-md px-3 py-2"
               autoComplete="off"
             />
-            {dropdownOpen && (
+            {dropdownOpen && !lookupResult && (
               <div className="absolute left-0 right-0 top-full z-20 mt-1 overflow-hidden rounded-lg border bg-white shadow-lg">
                 {searchLoading ? (
                   <div className="px-4 py-3 text-sm text-gray-500">Searching users...</div>

--- a/frontendNext/app/admin/view-orders/page.tsx
+++ b/frontendNext/app/admin/view-orders/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import Link from "next/link";
+import { Download, FileText } from "lucide-react";
 import { getApiUrl } from "@/utils/auth";
 import { formatLocalDate } from "@/utils/datetime";
 
@@ -32,6 +33,122 @@ function getStatusBadgeClass(status: string) {
         default:
             return "bg-gray-100 text-gray-700";
     }
+}
+
+function csvEscape(value: string) {
+    return `"${value.replace(/"/g, '""')}"`;
+}
+
+function escapeHtml(value: string) {
+    return value
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;")
+        .replace(/'/g, "&#039;");
+}
+
+function downloadTextFile(filename: string, content: string, mimeType: string) {
+    const blob = new Blob([content], { type: mimeType });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = filename;
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
+    URL.revokeObjectURL(url);
+}
+
+function buildOrderReportRows(orders: OrderItem[]) {
+    return orders.map((order) => ({
+        "Order ID": order.id,
+        Status: order.status || "-",
+        Type: order.action_type || "-",
+        Owner: order.owner_name || "-",
+        Borrower: order.borrower_name || "-",
+        Books: order.books.join("; ") || "-",
+        "Created Date": formatLocalDate(order.created_at, "-"),
+        "Due Date": formatLocalDate(order.due_at, "-"),
+        "Total Paid": `$${Number(order.total_paid_amount || 0).toFixed(2)}`,
+    }));
+}
+
+function exportOrdersCsv(orders: OrderItem[]) {
+    const rows = buildOrderReportRows(orders);
+    const headers = ["Order ID", "Status", "Type", "Owner", "Borrower", "Books", "Created Date", "Due Date", "Total Paid"];
+    const csv = [
+        headers.map(csvEscape).join(","),
+        ...rows.map((row) => headers.map((header) => csvEscape(row[header as keyof typeof row])).join(",")),
+    ].join("\n");
+
+    downloadTextFile("bookborrow-all-orders.csv", csv, "text/csv;charset=utf-8");
+}
+
+function exportOrdersPdf(orders: OrderItem[]) {
+    const rows = buildOrderReportRows(orders);
+    const headers = ["Order ID", "Status", "Type", "Owner", "Borrower", "Books", "Created Date", "Due Date", "Total Paid"];
+    const bodyRows = rows
+        .map(
+            (row) => `
+                <tr>
+                    ${headers.map((header) => `<td>${escapeHtml(row[header as keyof typeof row])}</td>`).join("")}
+                </tr>
+            `
+        )
+        .join("");
+
+    const iframe = document.createElement("iframe");
+    iframe.style.position = "fixed";
+    iframe.style.right = "0";
+    iframe.style.bottom = "0";
+    iframe.style.width = "0";
+    iframe.style.height = "0";
+    iframe.style.border = "0";
+    iframe.title = "BookBorrow all orders PDF export";
+
+    const html = `
+        <!doctype html>
+        <html>
+          <head>
+            <title>BookBorrow All Orders Report</title>
+            <style>
+              body { font-family: Arial, sans-serif; color: #111827; margin: 32px; }
+              h1 { font-size: 24px; margin: 0 0 4px; }
+              .meta { color: #4b5563; margin: 0 0 24px; }
+              table { border-collapse: collapse; width: 100%; }
+              th, td { border: 1px solid #e5e7eb; font-size: 11px; padding: 7px; text-align: left; vertical-align: top; }
+              th { background: #f9fafb; }
+              @media print { body { margin: 14mm; } }
+            </style>
+          </head>
+          <body>
+            <h1>BookBorrow All Orders Report</h1>
+            <p class="meta">${rows.length} order(s) | Generated ${escapeHtml(new Date().toLocaleString())}</p>
+            <table>
+              <thead><tr>${headers.map((header) => `<th>${escapeHtml(header)}</th>`).join("")}</tr></thead>
+              <tbody>${bodyRows}</tbody>
+            </table>
+          </body>
+        </html>
+    `;
+
+    document.body.appendChild(iframe);
+    const iframeDocument = iframe.contentWindow?.document;
+    if (!iframeDocument || !iframe.contentWindow) {
+        iframe.remove();
+        alert("Unable to prepare the PDF export. Please try again.");
+        return;
+    }
+
+    iframeDocument.open();
+    iframeDocument.write(html);
+    iframeDocument.close();
+    window.setTimeout(() => {
+        iframe.contentWindow?.focus();
+        iframe.contentWindow?.print();
+        window.setTimeout(() => iframe.remove(), 1000);
+    }, 100);
 }
 
 export default function ViewOrdersPage() {
@@ -146,9 +263,29 @@ export default function ViewOrdersPage() {
                     <h1 className="text-2xl font-bold">View Orders</h1>
                     <p className="text-gray-600">Browse and filter platform orders.</p>
                 </div>
-                <Link href="/admin" className="text-sm underline self-center">
-                    Back to Dashboard
-                </Link>
+                <div className="flex flex-wrap items-center gap-2">
+                    <button
+                        type="button"
+                        onClick={() => exportOrdersCsv(orders)}
+                        disabled={orders.length === 0}
+                        className="inline-flex items-center gap-2 rounded-lg border bg-white px-3 py-2 text-sm font-medium hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                        <Download className="h-4 w-4" />
+                        Export CSV
+                    </button>
+                    <button
+                        type="button"
+                        onClick={() => exportOrdersPdf(orders)}
+                        disabled={orders.length === 0}
+                        className="inline-flex items-center gap-2 rounded-lg bg-black px-3 py-2 text-sm font-medium text-white hover:bg-gray-800 disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                        <FileText className="h-4 w-4" />
+                        Export PDF
+                    </button>
+                    <Link href="/admin" className="text-sm underline self-center">
+                        Back to Dashboard
+                    </Link>
+                </div>
             </div>
 
             <div className="grid grid-cols-2 md:grid-cols-5 gap-4 mb-4">


### PR DESCRIPTION
## Summary

This PR improves the admin reporting and dashboard experience across user, book, financial, orders, and refunds pages.

## Changes Made

### Admin User Metrics
- Redesigned the User Metrics page to make the dashboard easier to read and more professional.
- Updated KPI cards to match the visual style used in the Book Metrics page.
- Improved spacing, layout consistency, and table presentation.

### Admin Book Metrics
- Fixed the user search dropdown so it closes once a user is selected.
- Added clickable links to listed books so admins can open the related book detail page directly.

### Admin Users
- Fixed the user search dropdown behavior after selecting a user.
- Confirmed admins can both make a user an admin and remove admin access.

### Financial Metrics
- Reordered the page so KPI cards appear first.
- Moved Platform Fee Setting and Date Filter into one row for a quicker workflow.
- Added quick date filters: Today, Last 7 days, This month, and Clear.
- Improved usability of the transaction filtering section.

### View Orders
- Added CSV export for all orders.
- Added PDF export for all orders.
- Export includes the current filtered order data for admin reporting.

### Refunds
- Added CSV export for refund reports.
- Added PDF export for refund reports.
- Export supports filtered refund data and fetches the full report set where pagination is used.

## Testing
- Ran frontend production build successfully:

<img width="1913" height="906" alt="image" src="https://github.com/user-attachments/assets/9ccfb25e-a17c-4dc4-958b-3b59323c8269" />
<img width="1178" height="732" alt="image" src="https://github.com/user-attachments/assets/66eedde3-5c12-4eb9-89c2-9c310dbbd67d" />
<img width="1283" height="785" alt="image" src="https://github.com/user-attachments/assets/2f54fc48-43ab-4ac8-bcb1-11328801827d" />
<img width="1376" height="780" alt="image" src="https://github.com/user-attachments/assets/72772acc-2ee2-42b3-8ead-7c0c571bdea6" />
<img width="1372" height="483" alt="image" src="https://github.com/user-attachments/assets/5ec681f4-8062-41b6-a134-7fb5cf350752" />
<img width="1332" height="341" alt="image" src="https://github.com/user-attachments/assets/21e96d5a-0004-48ba-849b-a18160606a7a" />
