### PR TITLE
VPS08: Fix - Stripe: transfer lender income from source charge

### DIFF
--- a/fastapi/services/order_service.py
+++ b/fastapi/services/order_service.py
@@ -707,13 +707,20 @@ class OrderService:
                         PaymentSplit.order_id == order.id
                     ).first()
                     if sp and sp.transfer_amount_cents > 0 and sp.connected_account_id:
-                        tr = _stripe.Transfer.create(
-                            amount=sp.transfer_amount_cents,
-                            currency=sp.currency or "aud",
-                            destination=sp.connected_account_id,
-                        )
+                        transfer_payload = {
+                            "amount": sp.transfer_amount_cents,
+                            "currency": sp.currency or "aud",
+                            "destination": sp.connected_account_id,
+                        }
+                        payment_intent = _stripe.PaymentIntent.retrieve(order.payment_id)
+                        latest_charge = getattr(payment_intent, "latest_charge", None)
+                        if latest_charge:
+                            transfer_payload["source_transaction"] = (
+                                latest_charge if isinstance(latest_charge, str) else latest_charge.id
+                            )
+                        tr = _stripe.Transfer.create(**transfer_payload)
                         sp.transfer_id = tr.id
-                        sp.transfer_status = tr.object
+                        sp.transfer_status = getattr(tr, "status", None) or tr.object
                         db.commit()
             except Exception as e:
                 db.rollback()

--- a/fastapi/services/payment_gateway_service.py
+++ b/fastapi/services/payment_gateway_service.py
@@ -25,6 +25,16 @@ def to_cents(amount) -> int:
     """Convert a decimal/float dollar amount to integer cents."""
     return int(round(float(amount or 0) * 100))
 
+def latest_charge_id_for_payment_intent(payment_id: str) -> Optional[str]:
+    """Return the latest charge for a PaymentIntent so transfers can use pending funds."""
+    if not payment_id:
+        return None
+    intent = stripe.PaymentIntent.retrieve(payment_id)
+    latest_charge = getattr(intent, "latest_charge", None)
+    if not latest_charge:
+        return None
+    return latest_charge if isinstance(latest_charge, str) else latest_charge.id
+
 logger = logging.getLogger(__name__)
 
 # -------- Helpers --------
@@ -1136,11 +1146,15 @@ def transfer_for_order(
     for sp in splits:
         if sp.transfer_amount_cents <= 0 or not sp.connected_account_id:
             continue
-        tr = stripe.Transfer.create(
-            amount=sp.transfer_amount_cents,
-            currency=sp.currency or "aud",
-            destination=sp.connected_account_id,
-        )
+        transfer_payload = {
+            "amount": sp.transfer_amount_cents,
+            "currency": sp.currency or "aud",
+            "destination": sp.connected_account_id,
+        }
+        latest_charge_id = latest_charge_id_for_payment_intent(sp.payment_id)
+        if latest_charge_id:
+            transfer_payload["source_transaction"] = latest_charge_id
+        tr = stripe.Transfer.create(**transfer_payload)
         sp.transfer_id = tr.id
         sp.transfer_status = tr.status
         db.add(sp)


### PR DESCRIPTION
## Summary
- Use the PaymentIntent latest charge as `source_transaction` when transferring lender income.
- Apply the same source-charge transfer behavior to the payment gateway transfer helper.
- Store the returned Stripe transfer status when available.

## Why
In Stripe test mode, card charges can remain pending until their availability date. The production Stripe account did not have enough available balance when the lender confirmed shipment, so the transfer silently failed with an insufficient available funds error. Binding the transfer to the charge lets Stripe create the transfer from that charge's funds instead of requiring current available platform balance.

## Validation
- `python3 -m py_compile fastapi/services/order_service.py fastapi/services/payment_gateway_service.py`
- `git diff --check`
- VPS backend Docker build completed successfully after applying the patch
- VPS backend health check passed after restart
- Verified the affected PaymentIntent exposes `latest_charge`, so future transfers will include `source_transaction`

## Notes
The already-canceled test order should not be backfilled with a transfer. This fix applies to new lender confirm-shipment flows.
