### PR TITLE
VPS09: Fix - Stripe deposit compensation transfers

### DIFF
--- a/fastapi/services/deposit_service.py
+++ b/fastapi/services/deposit_service.py
@@ -80,11 +80,19 @@ def _stripe_transfer_to_lender(order: Order, amount_cents: int) -> Optional[str]
     if amount_cents <= 0:
         return None
     try:
-        tr = stripe.Transfer.create(
-            amount=amount_cents,
-            currency="aud",
-            destination=order.owner.stripe_account_id,
-        )
+        transfer_payload = {
+            "amount": amount_cents,
+            "currency": "aud",
+            "destination": order.owner.stripe_account_id,
+        }
+        if order.payment_id:
+            payment_intent = stripe.PaymentIntent.retrieve(order.payment_id)
+            latest_charge = getattr(payment_intent, "latest_charge", None)
+            if latest_charge:
+                transfer_payload["source_transaction"] = (
+                    latest_charge if isinstance(latest_charge, str) else latest_charge.id
+                )
+        tr = stripe.Transfer.create(**transfer_payload)
         return tr.id
     except stripe.error.StripeError as e:
         print(f"[WARN] deposit transfer to lender failed: {e}")


### PR DESCRIPTION
## Summary
- update deposit compensation transfers to use the original PaymentIntent latest charge as `source_transaction`
- keep the existing fallback behavior when an order has no payment id or latest charge

## Root cause
Damage-deducted deposit compensation was sent as a plain Stripe transfer. On VPS, test-mode funds can still be pending, so the transfer can fail while the database state and borrower refund still continue.

## Impact
Future admin-approved deposit deductions/forfeitures should transfer the deducted deposit amount to the lender from the source charge instead of leaving it in the platform balance due to pending-balance timing.

## Validation
- `python3 -m py_compile fastapi/services/deposit_service.py`
- `git diff --check HEAD~1..HEAD`
- deployed the same hotfix to VPS backend and verified `/docs` responds
