### PR TITLE
Fix admin platform fee setting usage

### DIFF
--- a/fastapi/services/checkout_service.py
+++ b/fastapi/services/checkout_service.py
@@ -7,10 +7,10 @@ from sqlalchemy.orm import Session
 from models.checkout import Checkout, CheckoutItem, CheckoutCreate
 from models.book import Book
 from models.user import User 
+from services.service_fee_service import get_platform_service_fee_amount
 
 BASE_URL = "https://digitalapi.auspost.com.au/postage/parcel/domestic/calculate.json"
 AUSPOST_API_KEY = os.getenv("AUSPOST_CALCULATE_API_KEY")
-PLATFORM_SERVICE_FEE_AMOUNT = 2.0
 
 
 # -------- Shipping fee calculator --------
@@ -198,9 +198,9 @@ async def _apply_checkout_data(db: Session, checkout: Checkout, checkoutIn: Chec
                 shippingFeeTotal += float(item.shipping_quote)
                 processedOwners.add(item.owner_id)
 
-    # Step D: platform service fee is fixed at $2 per transaction.
+    # Step D: platform service fee is configured by admin and charged per transaction.
     subtotalBeforeServiceFee = depositTotal + ownerIncomeTotal + priceTotal + shippingFeeTotal
-    serviceFeeAmount = PLATFORM_SERVICE_FEE_AMOUNT if checkout.items else 0.0
+    serviceFeeAmount = get_platform_service_fee_amount(db) if checkout.items else 0.0
 
     # Step E: update checkout totals
     checkout.deposit = depositTotal

--- a/fastapi/services/order_service.py
+++ b/fastapi/services/order_service.py
@@ -13,6 +13,7 @@ from models.complaint import Complaint
 from sqlalchemy import or_
 from services.complaint_service import ComplaintService
 from services.notification_service import NotificationService
+from services.service_fee_service import get_platform_service_fee_amount
 from typing import Set
 import logging
 from services.email_service import (
@@ -23,7 +24,6 @@ from services.email_service import (
 from core.config import settings
 
 logger = logging.getLogger(__name__)
-PLATFORM_SERVICE_FEE_AMOUNT = 2.0
 
 class OrderService:
     """
@@ -102,9 +102,9 @@ class OrderService:
         return orders_data
 
     @staticmethod
-    def _calculate_service_fee(base_amount: float) -> float:
-        """Platform service fee is fixed at $2 per transaction."""
-        return PLATFORM_SERVICE_FEE_AMOUNT if float(base_amount or 0) > 0 else 0.0
+    def _calculate_service_fee(db: Session, base_amount: float) -> float:
+        """Platform service fee is configured by admin and charged per transaction."""
+        return get_platform_service_fee_amount(db) if float(base_amount or 0) > 0 else 0.0
 
     @staticmethod
     def _is_post_shipping(shipping_method: Optional[str]) -> bool:
@@ -124,14 +124,14 @@ class OrderService:
             - shipping_out_fee_amount
             - order_total
 
-        Return examples (post-PR-#88: fixed $2 service fee charged ONCE on
-        the first order in a multi-order checkout, $0 on the rest):
+        Return examples when the configured service fee is $2 and is charged
+        ONCE on the first order in a multi-order checkout, $0 on the rest:
             [
                 {
                     "items": [CheckoutItem(ci1), CheckoutItem(ci2)],  # borrow, owner1 (first)
                     "deposit_or_sale_amount": 25.0,                   # 10 + 15
                     "owner_income_amount": 2.5,
-                    "service_fee_amount": 2.0,                        # PLATFORM_SERVICE_FEE_AMOUNT
+                    "service_fee_amount": 2.0,                        # configured platform fee
                     "shipping_out_fee_amount": 3.0,                   # first post shipping_quote
                     "order_total": 32.5                               # 25 + 2.5 + 2 + 3
                 },
@@ -182,7 +182,7 @@ class OrderService:
             # charged ONCE per checkout — only on the first order, not on
             # subsequent orders in a multi-owner checkout.
             service_fee_base = deposit_or_sale_amount + owner_income_amount + shipping_out_fee_amount
-            service_fee_amount = OrderService._calculate_service_fee(service_fee_base) if index == 0 else 0.0
+            service_fee_amount = OrderService._calculate_service_fee(db, service_fee_base) if index == 0 else 0.0
 
             # keep original item
             results.append({

--- a/fastapi/services/service_fee_service.py
+++ b/fastapi/services/service_fee_service.py
@@ -1,5 +1,16 @@
 from sqlalchemy.orm import Session
+from models.admin_setting import AdminSetting
 from models.service_fee import ServiceFee, ServiceFeeUpdate
+
+DEFAULT_PLATFORM_SERVICE_FEE_AMOUNT = 2.0
+PLATFORM_SERVICE_FEE_SETTING_KEY = "platform_fee_per_transaction"
+
+
+def get_platform_service_fee_amount(db: Session) -> float:
+    setting = db.query(AdminSetting).filter(
+        AdminSetting.key == PLATFORM_SERVICE_FEE_SETTING_KEY
+    ).first()
+    return float(setting.max_value) if setting else DEFAULT_PLATFORM_SERVICE_FEE_AMOUNT
 
 def get_all_fees(db: Session):
     return db.query(ServiceFee).all()

--- a/fastapi/tests/conftest.py
+++ b/fastapi/tests/conftest.py
@@ -332,8 +332,10 @@ def restriction_guard_schema(deposit_strike_schema, engine):
     declarative_base in `models/checkout.py`, so they aren't picked up by
     `models.base.Base.metadata`. We create them table-by-table.
     """
+    from models.admin_setting import AdminSetting
     from models.checkout import Checkout, CheckoutItem
 
+    AdminSetting.__table__.create(bind=engine, checkfirst=True)
     Checkout.__table__.create(bind=engine, checkfirst=True)
     CheckoutItem.__table__.create(bind=engine, checkfirst=True)
     yield

--- a/fastapi/tests/test_platform_service_fee_setting.py
+++ b/fastapi/tests/test_platform_service_fee_setting.py
@@ -1,0 +1,32 @@
+from types import SimpleNamespace
+
+from models.admin_setting import AdminSetting
+from services.order_service import OrderService
+
+
+def _checkout_item(**overrides):
+    defaults = {
+        "action_type": "borrow",
+        "deposit": 20.0,
+        "price": 3.0,
+        "shipping_method": "pickup",
+        "shipping_quote": 0.0,
+    }
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def test_order_amounts_use_admin_configured_platform_fee_once(db, restriction_guard_schema):
+    db.add(AdminSetting(key="platform_fee_per_transaction", max_value=5.50))
+    db.flush()
+
+    order_groups = [
+        [_checkout_item(deposit=20.0, price=3.0)],
+        [_checkout_item(deposit=30.0, price=4.0)],
+    ]
+
+    amounts = OrderService.add_calculate_order_amounts(db, order_groups)
+
+    assert amounts[0]["service_fee_amount"] == 5.50
+    assert amounts[0]["order_total"] == 28.50
+    assert amounts[1]["service_fee_amount"] == 0.0


### PR DESCRIPTION
Description
This PR fixes the admin platform fee setting so it actually affects new checkout and order calculations.

Previously, the admin financial metrics page saved platform_fee_per_transaction, but checkout/order creation still used a hard-coded $2.00 service fee. This meant the admin setting appeared to update successfully but did not affect real transactions.

Changes
- Added shared backend helper to read the configured platform fee from admin_settings.
- Updated checkout total calculation to use the configured admin fee.
- Updated order creation amount calculation to use the configured admin fee.
- Preserved existing behavior where the platform fee is charged once on the first order in a multi-order checkout.

<img width="1551" height="383" alt="image" src="https://github.com/user-attachments/assets/ba8f8155-d6b4-489c-a29f-29084ed7efd1" />
