### PR TITLE
fix: remove admin-bypass self-service refund path from complaint flow

### DIFF
--- a/fastapi/models/payment_gateway.py
+++ b/fastapi/models/payment_gateway.py
@@ -135,11 +135,6 @@ class DistributeShippingFeeRequest(BaseModel):
     lender_account_id: str = Field(..., description="Connected account ID to receive the transfer")
 
 
-class PaymentRefundRequest(BaseModel):
-    reason: Optional[str] = Field(None, description="Reason for the refund")
-    refund_type: Optional[str] = Field("deposit", description="Refund type: deposit | shipping | full")
-
-
 class DisputeCreateRequest(BaseModel):
     payment_id: str
     user_id: str

--- a/fastapi/routes/payment_gateway.py
+++ b/fastapi/routes/payment_gateway.py
@@ -10,7 +10,6 @@ from models.payment_gateway import (
     PaymentInitiateRequest,
     PaymentStatusResponse,
     DistributeShippingFeeRequest,
-    PaymentRefundRequest,
     DisputeCreateRequest,
     PaymentDisputeRequest,
     DonationInitiateRequest,
@@ -111,21 +110,13 @@ def distribute_shipping_fee(payment_id: str, body: DistributeShippingFeeRequest,
         raise HTTPException(status_code=400, detail=str(e))
 
 
-@router.post("/payment/refund/{payment_id}", status_code=status.HTTP_200_OK)
-def refund_payment(payment_id: str, body: PaymentRefundRequest, db: Session = Depends(get_db)):
-    """
-    Refund a payment:
-    - Call Stripe Refund API
-    - Insert refund record into DB
-    - Update payment status accordingly
-    - Return refund details
-    """
-    try:
-        result = payment_gateway_service.refund_payment(payment_id, body.dict(), db=db)
-        return result
-    except Exception as e:
-        traceback.print_exc()
-        raise HTTPException(status_code=400, detail=str(e))
+# NOTE: The old `POST /payment/refund/{payment_id}` endpoint was removed.
+# It had no authentication and no order-state checks — any caller who knew a
+# payment_id could trigger a full Stripe refund, bypassing the BRD v2.5 deposit
+# arbitration flow (complaint -> pending_review -> admin ruling -> borrower claim).
+# Automatic refunds still happen via order cancellation (refund_on_cancel) and
+# clean-return confirmation (order_service -> refund_payment service fn).
+# Admin-driven refunds go through /refunds/admin/manual and /refunds/admin/{id}/retry.
 
 
 # ---------------------------

--- a/frontendNext/app/borrowing/[id]/page.tsx
+++ b/frontendNext/app/borrowing/[id]/page.tsx
@@ -2,7 +2,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { useParams, useRouter, useSearchParams } from "next/navigation";
+import { useParams, useRouter } from "next/navigation";
 import { Clock, Truck, ArrowLeft, AlertTriangle, ExternalLink } from "lucide-react";
 import CoverImg from "@/app/components/ui/CoverImg";
 import Card from "@/app/components/ui/Card";
@@ -69,7 +69,6 @@ const fetchOrderDetails = async (orderId: string): Promise<ApiOrder | null> => {
 export default function OrderDetailPage() {
   const { id } = useParams<{ id: string }>();
   const router = useRouter();
-  const searchParams = useSearchParams();
 
   const [order, setOrder] = useState<ApiOrder | null>(null);
   const [loading, setLoading] = useState(true);
@@ -92,11 +91,6 @@ export default function OrderDetailPage() {
 
   // Phase B.1 (Q5=A): second-confirm modal before lender submits a damage report.
   const [damageConfirmOpen, setDamageConfirmOpen] = useState(false);
-
-  // Refund modal state (from complaint redirect)
-  const [showRefundModal, setShowRefundModal] = useState(false);
-  const [refundReason, setRefundReason] = useState("");
-  const [refundDescription, setRefundDescription] = useState("");
 
   const resetDamageForm = () => {
     setDamageSeverity("none");
@@ -185,18 +179,6 @@ export default function OrderDetailPage() {
     setTrackingNumber(persistedTracking || "");
     setCarrier(persistedCarrier || "AUSPOST");
   }, [order]);
-
-  // Handle refund redirect from complaint form
-  useEffect(() => {
-    const action = searchParams.get("action");
-    if (action === "refund") {
-      const reason = searchParams.get("reason") || "";
-      const description = searchParams.get("description") || "";
-      setRefundReason(decodeURIComponent(reason));
-      setRefundDescription(decodeURIComponent(description));
-      setShowRefundModal(true);
-    }
-  }, [searchParams]);
 
   const statusMeta = useMemo(
     () => (order ? getDisplayedStatusMeta(order) : null),
@@ -1270,100 +1252,6 @@ export default function OrderDetailPage() {
               }}
             >
               Confirm
-            </Button>
-          </div>
-        </div>
-      </Modal>
-
-      {/* Refund Request Modal (from complaint redirect) */}
-      <Modal
-        isOpen={showRefundModal}
-        onClose={() => setShowRefundModal(false)}
-        title="Request Refund"
-      >
-        <div className="space-y-4">
-          <p className="text-sm text-gray-700">
-            You are requesting a refund for this order with the following reason:
-          </p>
-          
-          <div className="bg-gray-50 border border-gray-200 rounded-lg p-3">
-            <p className="text-sm font-medium text-gray-900">{refundReason}</p>
-            <p className="text-xs text-gray-600 mt-1">{refundDescription}</p>
-          </div>
-
-          <div className="rounded-md bg-blue-50 border border-blue-200 p-3 text-xs text-blue-800">
-            <p className="font-medium mb-1">About Refunds:</p>
-            <ul className="list-disc list-inside space-y-1">
-              <li>Your refund request will be reviewed by our team</li>
-              <li>Processing may take 5-7 business days</li>
-              <li>You can track the refund status in this order's Refund Status section</li>
-            </ul>
-          </div>
-
-          <div className="flex justify-end gap-2 pt-2">
-            <Button
-              variant="outline"
-              onClick={() => {
-                setShowRefundModal(false);
-                router.back();
-              }}
-            >
-              Cancel
-            </Button>
-            <Button
-              onClick={async () => {
-                try {
-                  if (!order?.paymentId) {
-                    toast.error("Payment information not found");
-                    return;
-                  }
-
-                  const token = getToken();
-                  if (!token) {
-                    toast.error("Please login first");
-                    router.push("/auth");
-                    return;
-                  }
-
-                  // Call the payment gateway refund API
-                  const res = await fetch(
-                    `${getApiUrl()}/api/v1/payment_gateway/payment/refund/${order.paymentId}`,
-                    {
-                      method: "POST",
-                      headers: {
-                        "Content-Type": "application/json",
-                        Authorization: `Bearer ${token}`,
-                        "Idempotency-Key": `refund-${order.id}-${Date.now()}`,
-                      },
-                      body: JSON.stringify({
-                        reason: refundReason,
-                        note: refundDescription,
-                      }),
-                    }
-                  );
-
-                  if (!res.ok) {
-                    const err = await res.json().catch(() => ({ detail: "Failed to process refund" }));
-                    throw new Error(err.detail || "Failed to process refund");
-                  }
-
-                  const data = await res.json();
-                  toast.success(`Refund of ${(data.amount_refunded / 100).toFixed(2)} ${data.currency} has been initiated`);
-                  
-                  // Refresh refund data
-                  const refundData = await getRefundsForOrder(id);
-                  setRefunds(refundData.refunds || []);
-                  
-                  setShowRefundModal(false);
-                  window.dispatchEvent(new Event("notif-update"));
-                } catch (err: any) {
-                  console.error(err);
-                  toast.error(err?.message || "Failed to process refund");
-                }
-              }}
-              className="bg-green-600 hover:bg-green-700"
-            >
-              Process Refund
             </Button>
           </div>
         </div>

--- a/frontendNext/app/supports-complaints/page.tsx
+++ b/frontendNext/app/supports-complaints/page.tsx
@@ -35,7 +35,6 @@ type ComplaintFormState = {
   orderId: string;
   respondentId: string;
   damageSeverity: "none" | "light" | "medium" | "severe";
-  needsRefund: boolean;
 };
 
 const initialComplaintForm: ComplaintFormState = {
@@ -45,7 +44,6 @@ const initialComplaintForm: ComplaintFormState = {
   orderId: "",
   respondentId: "",
   damageSeverity: "none",
-  needsRefund: false,
 };
 
 const ComplainPage: React.FC = () => {
@@ -205,15 +203,6 @@ const ComplainPage: React.FC = () => {
     if (newComplaint.orderId) {
       respondentId = await determineRespondentId(newComplaint.orderId, currentUser.id);
       console.log("🧩 Auto-detected respondentId:", respondentId);
-    }
-
-    // If user selects refund option, redirect to refund flow instead
-    if (newComplaint.needsRefund && newComplaint.orderId) {
-      const reason = encodeURIComponent(newComplaint.subject);
-      const description = encodeURIComponent(newComplaint.description);
-      router.push(`/borrowing/${newComplaint.orderId}?action=refund&reason=${reason}&description=${description}`);
-      setIsSubmitting(false);
-      return;
     }
 
     const complaintData: CreateComplaintRequest = {
@@ -556,45 +545,6 @@ const ComplainPage: React.FC = () => {
                       placeholder="Enter order ID if complaint is related to a specific order"
                     />
                   </div>
-
-                  {newComplaint.orderId && (
-                    <div className="bg-blue-50 border border-blue-200 rounded-md p-4">
-                      <label className="block text-sm font-medium text-gray-700 mb-3">
-                        Do you need a refund?
-                      </label>
-                      <div className="space-y-2">
-                        <label className="flex items-center">
-                          <input
-                            type="radio"
-                            name="refundOption"
-                            checked={!newComplaint.needsRefund}
-                            onChange={() => setNewComplaint({ ...newComplaint, needsRefund: false })}
-                            className="w-4 h-4 text-blue-600"
-                          />
-                          <span className="ml-2 text-sm text-gray-700">
-                            No, just file a complaint
-                          </span>
-                        </label>
-                        <label className="flex items-center">
-                          <input
-                            type="radio"
-                            name="refundOption"
-                            checked={newComplaint.needsRefund}
-                            onChange={() => setNewComplaint({ ...newComplaint, needsRefund: true })}
-                            className="w-4 h-4 text-blue-600"
-                          />
-                          <span className="ml-2 text-sm text-gray-700">
-                            Yes, I need a refund
-                          </span>
-                        </label>
-                      </div>
-                      {newComplaint.needsRefund && (
-                        <div className="mt-3 p-3 bg-amber-50 border border-amber-200 rounded text-xs text-amber-800">
-                          ⚠️ Selecting refund will redirect you to the refund process instead of filing a complaint.
-                        </div>
-                      )}
-                    </div>
-                  )}
 
                   <div>
                     <label className="block text-sm font-medium text-gray-700 mb-1">

--- a/frontendNext/utils/payments.ts
+++ b/frontendNext/utils/payments.ts
@@ -78,32 +78,6 @@ export async function distributeShippingFee(
   };
 }
 
-// refund payment
-export async function refundPayment(
-  paymentId: string,
-  opts?: { amount_cents?: number; reason?: string } // partial refunds in the future
-) {
-  const res = await axios.post(
-    `${API_URL}/api/v1/payment_gateway/payment/refund/${paymentId}`,
-    { reason: opts?.reason },
-    {
-      headers: {
-        Authorization: `Bearer ${localStorage.getItem("access_token")}`,
-        "Idempotency-Key": `refund-${paymentId}-${opts?.amount_cents ?? "full"}`,
-      },
-      withCredentials: true,
-    }
-  );
-  return res.data as {
-    payment_id: string;
-    refund_id: string;
-    status: "succeeded" | "pending" | "failed" | string;
-    amount_refunded: number; // cents
-    currency: string;        // e.g. "aud"
-    reason?: string | null;
-  };
-}
-
 // Create a new payment dispute (user-initiated)
 export async function createPaymentDispute(
   paymentId: string,


### PR DESCRIPTION
## Problem

The complaint form (`/supports-complaints`) had a **"Do you need a refund?"** option. Selecting "Yes" did **not** file a complaint — it redirected to a modal whose "Process Refund" button called `POST /payment_gateway/payment/refund/{payment_id}`.

That endpoint had:
- ❌ no `get_current_user` — **no authentication at all**
- ❌ no `get_current_admin`
- ❌ no caller-ownership check
- ❌ no order-state check (worked even while the borrower still held the book)

**Impact:** a borrower could receive a book, *not* return it, open a complaint, tick "I need a refund", and fully refund their own deposit — bypassing admin arbitration entirely. This violates the BRD v2.5 deposit dispute flow (`complaint → pending_review → admin ruling → borrower claim`). The endpoint was MVP6-era leftover that the v2.5 redesign never removed.

## Changes

**Backend**
- Remove the unauthenticated `POST /payment/refund/{payment_id}` route (`routes/payment_gateway.py`) and its `PaymentRefundRequest` schema (`models/payment_gateway.py`)

**Frontend**
- Remove the "Do you need a refund?" branch + `needsRefund` redirect from the complaint form (`supports-complaints/page.tsx`)
- Remove the `action=refund` redirect handler and "Request Refund" modal from the borrowing detail page (`borrowing/[id]/page.tsx`)
- Remove the now-dead `refundPayment()` helper (`utils/payments.ts`)

## Not affected (legitimate refund paths verified intact)

- Order cancellation — `refund_on_cancel` (`/payment/refund/cancel/{order_id}`), has PENDING_SHIPMENT guard
- Clean-return auto-refund — `order_service` → `refund_payment` **service function** (unchanged, still used)
- Admin refunds — `/refunds/admin/manual`, `/refunds/admin/{id}/retry` (`get_current_admin` protected)

## Verification

- **Backend** `pytest tests/`: 76 passed, 5 pre-existing failures (stale `test_deposit_arbitration` contracts, unrelated to this change)
- **HTTP**: `POST /payment/refund/{payment_id}` → `404 Not Found` (route gone); cancel + admin endpoints still respond
- **E2E (Playwright)**: complaint modal no longer shows the refund option even with an order ID filled; submitting a complaint creates a complaint and does NOT redirect into a refund flow

## After this fix

Filing a complaint always creates a complaint. Deposit refunds for damage disputes go through admin arbitration only.