### PR TITLE
fix: persist lender deposit-transfer outcome on the audit log

### DIFF
--- a/fastapi/migrations/versions/20260519_0001_deposit_transfer_audit_columns.py
+++ b/fastapi/migrations/versions/20260519_0001_deposit_transfer_audit_columns.py
@@ -1,0 +1,77 @@
+"""Persist the lender deposit-transfer outcome on the audit log.
+
+Adds to deposit_audit_log:
+  * transfer_id      — VARCHAR(255) NULL  (Stripe Transfer id, tr_...)
+  * transfer_status  — VARCHAR(50)  NULL  (succeeded / failed /
+                       skipped_no_account / skipped_zero_amount)
+
+Before this, admin_deduct / admin_forfeit obtained a Stripe transfer id and
+returned it in the HTTP response only — it was never persisted, so a
+deduction could not be reconciled against Stripe and a silent transfer
+failure was invisible.
+
+Defensive style mirrors 20260502_0004 — reruns on a partially-patched DB are
+no-ops; the reverse migration drops the columns.
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+from sqlalchemy import inspect, text
+
+
+revision: str = "20260519_0001"
+down_revision: Union[str, None] = "20260502_0004"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _table_exists(table_name: str) -> bool:
+    bind = op.get_bind()
+    return inspect(bind).has_table(table_name)
+
+
+def _column_exists(table_name: str, column_name: str) -> bool:
+    if not _table_exists(table_name):
+        return False
+    bind = op.get_bind()
+    columns = inspect(bind).get_columns(table_name)
+    return any(column["name"] == column_name for column in columns)
+
+
+def _execute_if_missing(table_name: str, column_name: str, ddl: str) -> None:
+    if _column_exists(table_name, column_name):
+        return
+    op.execute(text(ddl))
+
+
+def _execute_if_present(table_name: str, column_name: str, ddl: str) -> None:
+    if not _column_exists(table_name, column_name):
+        return
+    op.execute(text(ddl))
+
+
+def upgrade() -> None:
+    _execute_if_missing(
+        "deposit_audit_log",
+        "transfer_id",
+        "ALTER TABLE deposit_audit_log ADD COLUMN transfer_id VARCHAR(255) NULL",
+    )
+    _execute_if_missing(
+        "deposit_audit_log",
+        "transfer_status",
+        "ALTER TABLE deposit_audit_log ADD COLUMN transfer_status VARCHAR(50) NULL",
+    )
+
+
+def downgrade() -> None:
+    _execute_if_present(
+        "deposit_audit_log",
+        "transfer_status",
+        "ALTER TABLE deposit_audit_log DROP COLUMN transfer_status",
+    )
+    _execute_if_present(
+        "deposit_audit_log",
+        "transfer_id",
+        "ALTER TABLE deposit_audit_log DROP COLUMN transfer_id",
+    )

--- a/fastapi/models/deposit_audit_log.py
+++ b/fastapi/models/deposit_audit_log.py
@@ -47,6 +47,14 @@ class DepositAuditLog(Base):
                             nullable=True)
     note = Column(Text, nullable=True)
 
+    # Outcome of the Stripe transfer that moves a deducted/forfeited deposit to
+    # the lender. Without these, the transfer_id was returned in the HTTP
+    # response and then lost — a deduction could not be reconciled against
+    # Stripe, and a silent transfer failure was invisible.
+    # transfer_status: succeeded / failed / skipped_no_account / skipped_zero_amount
+    transfer_id = Column(String(255), nullable=True)
+    transfer_status = Column(String(50), nullable=True)
+
     created_at = Column(DateTime, server_default=func.now(), nullable=False, index=True)
 
     order = relationship("Order", foreign_keys=[order_id])

--- a/fastapi/services/deposit_service.py
+++ b/fastapi/services/deposit_service.py
@@ -72,13 +72,24 @@ def _deposit_cents(order: Order, db: Session) -> int:
     return int(round(float(order.deposit_or_sale_amount or 0) * 100))
 
 
-def _stripe_transfer_to_lender(order: Order, amount_cents: int) -> Optional[str]:
-    """Transfer deducted deposit amount to lender's connected Stripe account. Returns transfer_id or None."""
+def _stripe_transfer_to_lender(order: Order, amount_cents: int) -> Dict[str, Any]:
+    """Transfer a deducted/forfeited deposit to the lender's connected Stripe
+    account.
+
+    Returns {'id': transfer_id or None, 'status': str}, where status is one of:
+      - 'succeeded'            — transfer created, id is the Stripe tr_...
+      - 'failed'               — Stripe raised; id is None
+      - 'skipped_no_account'   — lender has no connected account; id is None
+      - 'skipped_zero_amount'  — nothing to transfer; id is None
+
+    Persisting the status is what makes a silent transfer failure visible and
+    a deduction reconcilable against Stripe.
+    """
     if not order.owner or not order.owner.stripe_account_id:
         print(f"[WARN] lender {order.owner_id} has no stripe_account_id — skipping deposit transfer")
-        return None
+        return {"id": None, "status": "skipped_no_account"}
     if amount_cents <= 0:
-        return None
+        return {"id": None, "status": "skipped_zero_amount"}
     try:
         transfer_payload = {
             "amount": amount_cents,
@@ -93,10 +104,10 @@ def _stripe_transfer_to_lender(order: Order, amount_cents: int) -> Optional[str]
                     latest_charge if isinstance(latest_charge, str) else latest_charge.id
                 )
         tr = stripe.Transfer.create(**transfer_payload)
-        return tr.id
+        return {"id": tr.id, "status": "succeeded"}
     except stripe.error.StripeError as e:
         print(f"[WARN] deposit transfer to lender failed: {e}")
-        return None
+        return {"id": None, "status": "failed"}
 
 
 def _stripe_refund(payment_id: str, amount_cents: int, reason: str) -> Dict[str, Any]:
@@ -277,11 +288,12 @@ def admin_deduct(db: Session, order_id: str, admin: User,
 
     strike_signal = _apply_strike(db, borrower, severity)
 
-    db.add(DepositAuditLog(
+    deduct_log = DepositAuditLog(
         order_id=order.id, actor_id=admin.user_id, actor_role="admin",
         action="partial_deduct", amount_cents=deducted, final_severity=severity,
         note=note or f"Admin deducted {DEDUCTION_PCT[severity]}% for {severity} damage. Awaiting borrower claim.",
-    ))
+    )
+    db.add(deduct_log)
 
     if strike_signal["restrict_applied"]:
         db.add(DepositAuditLog(
@@ -305,8 +317,13 @@ def admin_deduct(db: Session, order_id: str, admin: User,
     db.commit()
     db.refresh(order)
 
-    # Transfer deducted portion to lender (compensation for damage)
-    transfer_id = _stripe_transfer_to_lender(order, deducted)
+    # Transfer deducted portion to lender (compensation for damage), then
+    # persist the transfer outcome onto the audit row so the deduction can be
+    # reconciled against Stripe and a silent transfer failure stays visible.
+    transfer = _stripe_transfer_to_lender(order, deducted)
+    deduct_log.transfer_id = transfer["id"]
+    deduct_log.transfer_status = transfer["status"]
+    db.commit()
 
     return {
         "order_id": order.id,
@@ -314,7 +331,8 @@ def admin_deduct(db: Session, order_id: str, admin: User,
         "deducted_cents": deducted,
         "refund_ready_cents": to_refund,
         "strike": strike_signal,
-        "lender_transfer_id": transfer_id,
+        "lender_transfer_id": transfer["id"],
+        "lender_transfer_status": transfer["status"],
     }
 
 
@@ -338,11 +356,12 @@ def admin_forfeit(db: Session, order_id: str, admin: User, note: Optional[str] =
 
     strike_signal = _apply_strike(db, borrower, "severe")
 
-    db.add(DepositAuditLog(
+    forfeit_log = DepositAuditLog(
         order_id=order.id, actor_id=admin.user_id, actor_role="admin",
         action="forfeit", amount_cents=total_cents, final_severity="severe",
         note=note or "Admin forfeited the full deposit (severe damage / non-return).",
-    ))
+    )
+    db.add(forfeit_log)
 
     if strike_signal["restrict_applied"]:
         db.add(DepositAuditLog(
@@ -366,8 +385,13 @@ def admin_forfeit(db: Session, order_id: str, admin: User, note: Optional[str] =
     db.commit()
     db.refresh(order)
 
-    # Transfer full deposit to lender (severe damage / non-return)
-    transfer_id = _stripe_transfer_to_lender(order, total_cents)
+    # Transfer full deposit to lender (severe damage / non-return), then
+    # persist the transfer outcome onto the audit row so the forfeit can be
+    # reconciled against Stripe and a silent transfer failure stays visible.
+    transfer = _stripe_transfer_to_lender(order, total_cents)
+    forfeit_log.transfer_id = transfer["id"]
+    forfeit_log.transfer_status = transfer["status"]
+    db.commit()
 
     return {
         "order_id": order.id,
@@ -375,7 +399,8 @@ def admin_forfeit(db: Session, order_id: str, admin: User, note: Optional[str] =
         "deducted_cents": total_cents,
         "refunded_cents": 0,
         "strike": strike_signal,
-        "lender_transfer_id": transfer_id,
+        "lender_transfer_id": transfer["id"],
+        "lender_transfer_status": transfer["status"],
     }
 
 

--- a/fastapi/tests/test_deposit_transfer_record.py
+++ b/fastapi/tests/test_deposit_transfer_record.py
@@ -1,0 +1,153 @@
+"""
+Tests for persisting the lender deposit-transfer outcome.
+
+Before this change, admin_deduct / admin_forfeit obtained a Stripe transfer id
+and returned it in the HTTP response only -- it was never persisted, so a
+deduction could not be reconciled against Stripe and a silent transfer failure
+was invisible. Two pieces are covered here:
+
+  1. _stripe_transfer_to_lender -- now returns {'id', 'status'} with a status
+     of succeeded / failed / skipped_no_account / skipped_zero_amount.
+  2. admin_deduct / admin_forfeit -- write that id + status onto the
+     DepositAuditLog row for the deduction / forfeit.
+"""
+
+import uuid
+from types import SimpleNamespace
+
+import pytest
+import stripe
+
+from services import deposit_service
+from services.deposit_service import admin_deduct, admin_forfeit
+from models.deposit_audit_log import DepositAuditLog
+
+
+# ===========================================================================
+# 1. _stripe_transfer_to_lender -- return shape
+# ===========================================================================
+
+def _fake_order(*, stripe_account_id="acct_lender", payment_id=None):
+    """Minimal duck-typed order -- _stripe_transfer_to_lender only touches
+    .owner(.stripe_account_id), .owner_id and .payment_id."""
+    return SimpleNamespace(
+        owner=SimpleNamespace(stripe_account_id=stripe_account_id),
+        owner_id="user-lender",
+        payment_id=payment_id,
+    )
+
+
+class TestStripeTransferToLenderResult:
+    def test_success_returns_id_and_succeeded(self, monkeypatch):
+        monkeypatch.setattr(stripe.Transfer, "create",
+                            lambda **kw: SimpleNamespace(id="tr_ok"))
+
+        result = deposit_service._stripe_transfer_to_lender(_fake_order(), 500)
+
+        assert result == {"id": "tr_ok", "status": "succeeded"}
+
+    def test_stripe_error_returns_failed(self, monkeypatch):
+        """A Stripe outage must surface as status='failed', not a silent None."""
+        def _boom(**kw):
+            raise stripe.error.StripeError("simulated Stripe outage")
+
+        monkeypatch.setattr(stripe.Transfer, "create", _boom)
+
+        result = deposit_service._stripe_transfer_to_lender(_fake_order(), 500)
+
+        assert result == {"id": None, "status": "failed"}
+
+    def test_no_connected_account_returns_skipped(self):
+        """Lender never onboarded Stripe -- distinct status, not 'failed'."""
+        result = deposit_service._stripe_transfer_to_lender(
+            _fake_order(stripe_account_id=None), 500,
+        )
+
+        assert result == {"id": None, "status": "skipped_no_account"}
+
+    def test_zero_amount_returns_skipped(self):
+        result = deposit_service._stripe_transfer_to_lender(_fake_order(), 0)
+
+        assert result == {"id": None, "status": "skipped_zero_amount"}
+
+
+# ===========================================================================
+# 2. admin_deduct / admin_forfeit -- persist the transfer onto the audit log
+# ===========================================================================
+
+@pytest.fixture
+def fake_transfer(monkeypatch):
+    """Mock stripe.Transfer.create to a deterministic success."""
+    monkeypatch.setattr(stripe.Transfer, "create",
+                        lambda **kw: SimpleNamespace(id="tr_integration"))
+
+
+def _audit_row(db, order_id, action):
+    return (
+        db.query(DepositAuditLog)
+        .filter(DepositAuditLog.order_id == order_id,
+                DepositAuditLog.action == action)
+        .first()
+    )
+
+
+class TestAdminDeductPersistsTransfer:
+    def test_deduct_records_succeeded_transfer(
+        self, db, make_order, make_user, fake_transfer,
+    ):
+        # users.stripe_account_id is UNIQUE; uuid-suffix it so the integration
+        # tests don't collide under sqlite + SAVEPOINT isolation leakage.
+        lender = make_user(name="Lender",
+                           stripe_account_id=f"acct_{uuid.uuid4().hex[:12]}")
+        borrower = make_user(name="Borrower")
+        admin = make_user(name="Admin", is_admin=True)
+        # with_payment=False -> no Stripe PaymentIntent.retrieve inside the transfer
+        order = make_order(owner=lender, borrower=borrower, with_payment=False)
+
+        result = admin_deduct(db, order.id, admin, severity="light")
+
+        log = _audit_row(db, order.id, "partial_deduct")
+        assert log is not None
+        assert log.transfer_id == "tr_integration"
+        assert log.transfer_status == "succeeded"
+        assert result["lender_transfer_id"] == "tr_integration"
+        assert result["lender_transfer_status"] == "succeeded"
+
+    def test_deduct_records_skipped_when_lender_has_no_account(
+        self, db, make_order, make_user,
+    ):
+        """Realistic current-production case: lender never onboarded Stripe.
+        The deduction is still recorded -- with an honest skipped status, not
+        a silent None that hides the un-transferred money."""
+        lender = make_user(name="Lender No Stripe")  # no stripe_account_id
+        borrower = make_user(name="Borrower")
+        admin = make_user(name="Admin", is_admin=True)
+        order = make_order(owner=lender, borrower=borrower, with_payment=False)
+
+        admin_deduct(db, order.id, admin, severity="light")
+
+        log = _audit_row(db, order.id, "partial_deduct")
+        assert log is not None
+        assert log.transfer_id is None
+        assert log.transfer_status == "skipped_no_account"
+
+
+class TestAdminForfeitPersistsTransfer:
+    def test_forfeit_records_succeeded_transfer(
+        self, db, make_order, make_user, fake_transfer,
+    ):
+        # users.stripe_account_id is UNIQUE; uuid-suffix it so the integration
+        # tests don't collide under sqlite + SAVEPOINT isolation leakage.
+        lender = make_user(name="Lender",
+                           stripe_account_id=f"acct_{uuid.uuid4().hex[:12]}")
+        borrower = make_user(name="Borrower")
+        admin = make_user(name="Admin", is_admin=True)
+        order = make_order(owner=lender, borrower=borrower, with_payment=False)
+
+        result = admin_forfeit(db, order.id, admin)
+
+        log = _audit_row(db, order.id, "forfeit")
+        assert log is not None
+        assert log.transfer_id == "tr_integration"
+        assert log.transfer_status == "succeeded"
+        assert result["lender_transfer_status"] == "succeeded"


### PR DESCRIPTION
## Problem

When an admin rules damage, `admin_deduct` / `admin_forfeit` transfer the deducted/forfeited deposit to the lender via a Stripe transfer and get back a `transfer_id` — but it was **only returned in the HTTP response, never persisted**.

Two consequences:

1. **No reconciliation** — the system records the *amount* deducted (`deposit_audit_log.amount_cents`, `orders.deposit_deducted_cents`) but has no link to the actual Stripe transfer. You can't answer "did this 25% actually move, and what's its `tr_...` id?" without manually digging in the Stripe Dashboard.
2. **Silent failure** — the transfer runs *after* `db.commit()`, and `_stripe_transfer_to_lender` swallowed `StripeError` into `None`. So a failed transfer left the DB showing the deposit as deducted/forfeited with **no money moved and no trace** — DB and Stripe diverge invisibly.

## Fix

- **`deposit_audit_log`** — add `transfer_id` + `transfer_status` columns.
- **`_stripe_transfer_to_lender`** — return `{id, status}` instead of `Optional[str]`, where `status` is one of `succeeded` / `failed` / `skipped_no_account` / `skipped_zero_amount`. A silent transfer failure now has an honest status.
- **`admin_deduct` / `admin_forfeit`** — write the transfer id + status onto the `DepositAuditLog` row for the deduction/forfeit, and surface `lender_transfer_status` in the response.
- **alembic `20260519_0001`** — migration for the two columns (defensive style: idempotent, reversible). Already applied to the dev DB.

## Tests

New `test_deposit_transfer_record.py` — 7 tests:
- `_stripe_transfer_to_lender` return shape for all 4 status outcomes (unit).
- `admin_deduct` / `admin_forfeit` persist the transfer id + status onto the audit log, including the realistic "lender never onboarded Stripe → `skipped_no_account`" case (integration).

Full backend suite: **83 passed, 5 failed**. Baseline without this change: **76 passed, 5 failed** — 83 = 76 + 7 new tests, zero regressions. The 5 failures are the pre-existing stale `test_deposit_arbitration.py` set, unrelated.

## Not addressed here (possible follow-up)

This makes a failed transfer *visible* but does not *retry* it. A natural follow-up is an admin retry endpoint for `transfer_status='failed'` rows, mirroring the existing `/refunds/admin/{id}/retry`.
